### PR TITLE
Implement constrained direct memory writes

### DIFF
--- a/lib/tinykvm/common.hpp
+++ b/lib/tinykvm/common.hpp
@@ -37,7 +37,7 @@ namespace tinykvm
 		uint32_t reset_free_work_mem = 0; /* reset_to() */
 		uint64_t vmem_base_address = 0;
 		std::string_view binary = {};
-		std::vector<VirtualRemapping> remappings;
+		std::vector<VirtualRemapping> remappings {};
 
 		bool verbose_loader = false;
 		bool short_lived = false;
@@ -46,7 +46,7 @@ namespace tinykvm
 		/* When enabled, master VMs will write directly
 		   to their own main memory instead of memory banks,
 		   allowing forks to immediately see changes. */
-		bool master_direct_memory_writes = true;
+		bool master_direct_memory_writes = false;
 		/* When enabled, split hugepages during page faults. */
 		bool split_hugepages = false;
 		/* When enabled, reset_to() will accept a different

--- a/lib/tinykvm/memory.hpp
+++ b/lib/tinykvm/memory.hpp
@@ -22,6 +22,9 @@ struct vMemory {
 	/* Optional executable memory range */
 	uint64_t vmem_exec_begin = 0;
 	uint64_t vmem_exec_end   = 0;
+	/* Counter for the number of pages that have been unlocked
+	   in the main memory. */
+	size_t unlocked_pages = 0;
 	/* Linear memory */
 	char*  ptr;
 	size_t size;
@@ -61,6 +64,14 @@ struct vMemory {
 	MemoryBank::Page new_hugepage();
 
 	bool compare(const vMemory& other);
+	/* When a main VM has direct memory writes enabled, it can
+	   write directly to its own memory, but in order to constrain
+	   the memory usage, we need to keep track of the number of
+	   pages that have been unlocked. */
+	void increment_unlocked_pages(size_t pages);
+	size_t unlocked_memory_pages() const noexcept {
+		return unlocked_pages;
+	}
 
 	VirtualMem vmem() const;
 

--- a/lib/tinykvm/memory_bank.hpp
+++ b/lib/tinykvm/memory_bank.hpp
@@ -50,12 +50,14 @@ struct MemoryBank {
 
 struct MemoryBanks {
 	static constexpr unsigned FIRST_BANK_IDX = 2;
+	static constexpr uint64_t ARENA_BASE_ADDRESS = 0x7000000000;
 
 	MemoryBanks(Machine&, const MachineOptions&);
 
 	MemoryBank& get_available_bank(size_t n_pages);
 	void reset(const MachineOptions&);
 	void set_max_pages(size_t new_max);
+	size_t max_pages() const noexcept { return m_max_pages; }
 
 	bool using_hugepages() const noexcept { return m_using_hugepages; }
 

--- a/tests/unit/fork.cpp
+++ b/tests/unit/fork.cpp
@@ -42,7 +42,7 @@ extern void prints_hello_world() {
 
 	// Make machine forkable (no working memory)
 	machine.prepare_copy_on_write(65536);
-	REQUIRE(machine.banked_memory_pages() == 4);
+	REQUIRE(machine.banked_memory_pages() == 5);
 	REQUIRE(machine.is_forkable());
 	REQUIRE(!machine.is_forked());
 
@@ -249,7 +249,7 @@ extern int get_value() {
 
 	// Make machine forkable (with working memory)
 	machine.prepare_copy_on_write(65536);
-	REQUIRE(machine.banked_memory_pages() == 4);
+	REQUIRE(machine.banked_memory_pages() == 5);
 	REQUIRE(machine.is_forkable());
 	REQUIRE(!machine.is_forked());
 
@@ -293,10 +293,10 @@ extern int get_value() {
 
 	// Value now starts at 1 due to the change in main VM
 	fork1.timed_vmcall(funcaddr, 4.0f);
-	REQUIRE(fork1.return_value() == 2);
+	REQUIRE(fork1.return_value() == 1);
 
 	fork2.timed_vmcall(funcaddr, 4.0f);
-	REQUIRE(fork2.return_value() == 2);
+	REQUIRE(fork2.return_value() == 1);
 }
 
 TEST_CASE("Fork sanity checks w/crashes", "[Fork]")
@@ -363,7 +363,9 @@ extern void crash() {
 TEST_CASE("Fork and run main()", "[Fork]")
 {
 	const auto binary = build_and_load(R"M(
+#include <stdio.h>
 int main() {
+	printf("Hello World!\n");
 	return 666;
 }
 static unsigned value = 12345;
@@ -378,17 +380,20 @@ int func2() {
 }
 )M");
 
-	tinykvm::Machine machine { binary, { .max_mem = MAX_MEMORY } };
+	tinykvm::Machine machine { binary, {
+		.max_mem = MAX_MEMORY,
+		.master_direct_memory_writes = true
+	} };
 
 	// We need to create a Linux environment for runtimes to work well
 	machine.setup_linux({"fork"}, env);
 	REQUIRE(machine.banked_memory_pages() == 0);
 
-	// Make machine forkable (with *NO* working memory)
+	// Make machine forkable (with 4MB working memory)
 	machine.prepare_copy_on_write(4ULL << 20);
+	REQUIRE(machine.banked_memory_capacity_bytes() == 4ULL << 20);
 	REQUIRE(machine.is_forkable());
 	REQUIRE(!machine.is_forked());
-	REQUIRE(machine.return_value() == 0); // Initial register value
 
 	// Run for at most 4 seconds before giving up
 	machine.run(4.0f);
@@ -397,11 +402,10 @@ int func2() {
 	// We only gave it 4MB working memory, so lets mmap allocate that and verify
 	// that if we write more than that, we get an exception thrown
 	REQUIRE_THROWS([&] () {
-		const size_t size = 5ULL << 20;
-		uint64_t addr = machine.mmap_allocate(5ULL << 20);
+		const size_t size = 8ULL << 20;
+		uint64_t addr = machine.mmap_allocate(size);
 		char buffer[4096];
-		for (int i = 0; i < 4096; i++)
-			buffer[i] = 'a';
+		memset(buffer, 'a', sizeof(buffer));
 		for (size_t i = 0; i < size; i += 4096)
 		{
 			machine.copy_to_guest(addr + i, buffer, 4096);
@@ -411,11 +415,33 @@ int func2() {
 	}());
 
 	// There are banked pages now
-	const auto banked_pages_before = machine.banked_memory_pages();
+	const auto banked_pages_before = machine.main_memory().unlocked_memory_pages();
 	REQUIRE(banked_pages_before > 500);
 
+	// We have no free memory now, so make another VM
+	tinykvm::Machine machine2 { binary, {
+		.max_mem = MAX_MEMORY,
+		.master_direct_memory_writes = true
+	} };
+
+	// We need to create a Linux environment for runtimes to work well
+	machine2.setup_linux({"fork"}, env);
+	REQUIRE(machine2.banked_memory_pages() == 0);
+
+	// Make machine forkable (with 4MB working memory)
+	machine2.prepare_copy_on_write(4ULL << 20);
+	REQUIRE(machine2.banked_memory_capacity_bytes() == 4ULL << 20);
+	REQUIRE(machine2.is_forkable());
+	REQUIRE(!machine2.is_forked());
+
+	// Run for at most 4 seconds before giving up
+	machine2.run(4.0f);
+	REQUIRE(machine2.return_value() == 666); // Main() return value
+
+	machine2.prepare_copy_on_write(0);
+
 	// Create fork
-	auto fork1 = tinykvm::Machine { machine, {
+	auto fork1 = tinykvm::Machine { machine2, {
 		.max_mem = MAX_MEMORY, .max_cow_mem = MAX_COWMEM
 	} };
 	REQUIRE(fork1.return_value() == 666); // Main() return value
@@ -425,25 +451,17 @@ int func2() {
 
 	fork1.vmcall("func2");
 	REQUIRE(fork1.return_value() == 54321);
-
-	// This is problematic, but we will try to fix this later
-	// Forked VM is supposed to diverge from the main VM, regardless of mode
-	machine.vmcall("set_value", 99999);
-	fork1.vmcall("func1");
-	REQUIRE(fork1.return_value() == 99999);
-
-	REQUIRE(machine.banked_memory_pages() == banked_pages_before);
 	REQUIRE(fork1.banked_memory_pages() > 0);
 
 	for (int i = 0; i < 20; i++)
 	{
-		fork1.reset_to(machine, {
+		fork1.reset_to(machine2, {
 			.max_mem = MAX_MEMORY,
 			.max_cow_mem = MAX_COWMEM,
 		});
 
 		fork1.vmcall("func1");
-		REQUIRE(fork1.return_value() == 99999);
+		REQUIRE(fork1.return_value() == 12345);
 
 		fork1.vmcall("func2");
 		REQUIRE(fork1.return_value() == 54321);


### PR DESCRIPTION
After two days of hammering the keyboard and getting increasingly annoyed, I've finally made the second option work. It turned out better than I thought because it has some nice properties. Here's a short explanation:

- The main VM is turned entirely copy-on-write but importantly with no other pagetable changes. That is, every writable page is turned into read-only + cloneable. The equivalent of iterating the page table and toggling bits.
- The main VM has a property called "direct main memory writes" enabled.
- When a read-only page is being written to, a page fault happens that enters paging. Paging sees that it's a VM with direct memory writes, and just unlocks the page by making it writable again. No other change, making it very fast. It also counts the pages that are unlocked. And if the number of unlocked pages exceeds the set working memory, it throws an out of memory exception.

When the VM has been loaded, it is again made copy-on-write and any forks will see the pagetables in the same way as before (without this feature). So, bottom line is: Not a single extra page is used, but we can still constrain pages used.