### PR TITLE
Handle ioctl FIOCLEX and FIONCLEX so python can open script files

### DIFF
--- a/lib/tinykvm/linux/system_calls.cpp
+++ b/lib/tinykvm/linux/system_calls.cpp
@@ -579,6 +579,32 @@ void Machine::setup_linux_system_calls()
 					}
 				}
 				break;
+			case FIOCLEX: // Set close-on-exec
+				if (int(regs.rdi) >= 0 && int(regs.rdi) < 3) {
+					// Ignore
+					regs.rax = 0;
+				} else {
+					const int result = ioctl(fd, FIOCLEX);
+					if (result < 0) {
+						regs.rax = -errno;
+					} else {
+						regs.rax = 0;
+					}
+				}
+				break;
+			case FIONCLEX: // Clear close-on-exec
+				if (int(regs.rdi) >= 0 && int(regs.rdi) < 3) {
+					// Ignore
+					regs.rax = 0;
+				} else {
+					const int result = ioctl(fd, FIONCLEX);
+					if (result < 0) {
+						regs.rax = -errno;
+					} else {
+						regs.rax = 0;
+					}
+				}
+				break;
 			default:
 				regs.rax = -EINVAL;
 			}


### PR DESCRIPTION
FIOCLEX is necessary for my ubuntu 24.04 python3 to open a python file. With it I can now run `kvmserver -p python3 hello.py` and have it `print("hello")`. Implemented FIONCLEX while there.

I'm skipping fds 0,1,2 like the code around me but I'm not sure if that's necessary.