### PR TITLE
Reenable F_SETFL which is necessary for enabling O_NONBLOCK

### DIFF
--- a/lib/tinykvm/linux/system_calls.cpp
+++ b/lib/tinykvm/linux/system_calls.cpp
@@ -1646,8 +1646,11 @@ void Machine::setup_linux_system_calls(bool unsafe_syscalls)
 				else if (cmd == F_SETFL)
 				{
 					const int writable_fd = cpu.machine().fds().translate_writable_vfd(vfd);
-					(void)writable_fd;
-					regs.rax = 0; // Ignore the new flags
+					const int flags = fcntl(writable_fd, cmd, regs.rdx);
+					if (flags < 0)
+						regs.rax = -errno;
+					else
+						regs.rax = 0;
 				}
 				else if (cmd == F_GETLK64)
 				{


### PR DESCRIPTION
This should be safe as file access mode and file creation flags are ignored according to the man page.