### PR TITLE
Necessary to disallow read for empty path on debian bookworm

### DIFF
--- a/lib/tinykvm/linux/fds.cpp
+++ b/lib/tinykvm/linux/fds.cpp
@@ -478,6 +478,9 @@ namespace tinykvm
 
 	bool FileDescriptors::is_readable_path(std::string& modifiable_path) const noexcept
 	{
+		if (modifiable_path.empty())
+			return false;
+
 		if (!m_open_readable)
 			return false;
 		if (m_open_readable(modifiable_path)) {


### PR DESCRIPTION
No idea why this is only necessary on Debian Bookworm (works without on RHEL9 and Ubuntu 24.04) but looks like I should not have removed it in #39.