### PR TITLE
Track CoW pages to avoid iterating over the page tables

### DIFF
--- a/lib/tinykvm/amd64/paging.cpp
+++ b/lib/tinykvm/amd64/paging.cpp
@@ -526,7 +526,7 @@ void foreach_page_makecow(vMemory& mem, uint64_t kernel_end, uint64_t shared_mem
 	}
 	foreach_page(mem,
 	[=] (uint64_t addr, uint64_t& entry, size_t /*size*/) {
-		if (addr < shared_memory_boundary && addr != 0xffe00000) {
+		if (addr < shared_memory_boundary) {
 			const uint64_t flags = (PDE64_PRESENT | PDE64_RW);
 			if ((entry & flags) == flags) {
 				entry &= ~PDE64_RW;

--- a/lib/tinykvm/amd64/paging.cpp
+++ b/lib/tinykvm/amd64/paging.cpp
@@ -727,7 +727,8 @@ char * writable_page_at(vMemory& memory, uint64_t addr, uint64_t verify_flags, b
 
 						/* Return 4k page offset to new duplicated page. */
 						const uint64_t e = index_from_pt_entry(addr);
-						memory.record_cow_page(addr, pt[e]);
+						if (pt[e] & PDE64_USER)
+							memory.record_cow_leaf_user_page(addr);
 						return (char *)page.pmem + e * PAGE_SIZE;
 					}
 
@@ -772,7 +773,8 @@ entry_is_no_longer_copy_on_write:
 							pt[e] &= ~PDE64_CLONEABLE;
 							pt[e] |= PDE64_RW | PDE64_PRESENT;
 						}
-						memory.record_cow_page(addr, pt[e]);
+						if (pt[e] & PDE64_USER)
+							memory.record_cow_leaf_user_page(addr);
 						CLPRINT("-> Cloning a PT entry: 0x%lX\n", pt[e]);
 					}
 					if ((pt[e] & verify_flags) == verify_flags) {

--- a/lib/tinykvm/amd64/paging.cpp
+++ b/lib/tinykvm/amd64/paging.cpp
@@ -727,6 +727,7 @@ char * writable_page_at(vMemory& memory, uint64_t addr, uint64_t verify_flags, b
 
 						/* Return 4k page offset to new duplicated page. */
 						const uint64_t e = index_from_pt_entry(addr);
+						memory.record_cow_page(addr, pt[e]);
 						return (char *)page.pmem + e * PAGE_SIZE;
 					}
 
@@ -771,6 +772,7 @@ entry_is_no_longer_copy_on_write:
 							pt[e] &= ~PDE64_CLONEABLE;
 							pt[e] |= PDE64_RW | PDE64_PRESENT;
 						}
+						memory.record_cow_page(addr, pt[e]);
 						CLPRINT("-> Cloning a PT entry: 0x%lX\n", pt[e]);
 					}
 					if ((pt[e] & verify_flags) == verify_flags) {

--- a/lib/tinykvm/memory.cpp
+++ b/lib/tinykvm/memory.cpp
@@ -53,7 +53,7 @@ void vMemory::record_cow_page(uint64_t addr, uint64_t entry)
 	// If the page is writable, we will restore the original
 	// memory from the master VM. We only care about leaf pages.
 	if (machine.is_forked() && entry & PDE64_USER) {
-		cow_written_pages.insert(addr);
+		cow_written_pages.push_back(addr);
 	}
 }
 

--- a/lib/tinykvm/memory.cpp
+++ b/lib/tinykvm/memory.cpp
@@ -1,4 +1,5 @@
 #include "machine.hpp"
+#include <algorithm>
 #include <cstring>
 #include <sys/mman.h>
 #include <stdexcept>
@@ -53,7 +54,8 @@ void vMemory::record_cow_page(uint64_t addr, uint64_t entry)
 	// If the page is writable, we will restore the original
 	// memory from the master VM. We only care about leaf pages.
 	if (machine.is_forked() && entry & PDE64_USER) {
-		cow_written_pages.push_back(addr);
+		auto it = std::lower_bound(cow_written_pages.begin(), cow_written_pages.end(), addr);
+		cow_written_pages.insert(it, addr);
 	}
 }
 

--- a/lib/tinykvm/memory.cpp
+++ b/lib/tinykvm/memory.cpp
@@ -92,7 +92,7 @@ bool vMemory::fork_reset(const Machine& main_vm, const MachineOptions& options)
 				tinykvm::page_at(const_cast<vMemory&> (main_vm.main_memory()), addr,
 					[&](uint64_t, uint64_t& entry, size_t) {
 						if ((entry & PDE64_DIRTY) == 0) {
-							madvise(our_page, page_size, MADV_FREE);
+							madvise(our_page, page_size, MADV_DONTNEED);
 							duplicate = false;
 						}
 					});

--- a/lib/tinykvm/memory.hpp
+++ b/lib/tinykvm/memory.hpp
@@ -4,6 +4,7 @@
 #include "virtual_mem.hpp"
 #include <cstddef>
 #include <mutex>
+#include <set>
 #include <string_view>
 
 namespace tinykvm {
@@ -16,6 +17,7 @@ struct vMemory {
 	}
 
 	Machine& machine;
+	std::set<uint64_t> cow_written_pages{};
 	uint64_t physbase;
 	uint64_t safebase;
 	uint64_t page_tables;
@@ -76,6 +78,7 @@ struct vMemory {
 	VirtualMem vmem() const;
 
 	[[noreturn]] static void memory_exception(const char*, uint64_t, uint64_t);
+	void record_cow_page(uint64_t addr, uint64_t entry);
 	bool fork_reset(const Machine&, const MachineOptions&); // Returns true if a full reset was done
 	void fork_reset(const vMemory& other, const MachineOptions&);
 	static vMemory New(Machine&, const MachineOptions&, uint64_t phys, uint64_t safe, size_t size);

--- a/lib/tinykvm/memory.hpp
+++ b/lib/tinykvm/memory.hpp
@@ -4,7 +4,6 @@
 #include "virtual_mem.hpp"
 #include <cstddef>
 #include <mutex>
-#include <set>
 #include <string_view>
 
 namespace tinykvm {
@@ -17,7 +16,7 @@ struct vMemory {
 	}
 
 	Machine& machine;
-	std::set<uint64_t> cow_written_pages{};
+	std::vector<uint64_t> cow_written_pages{};
 	uint64_t physbase;
 	uint64_t safebase;
 	uint64_t page_tables;

--- a/lib/tinykvm/memory.hpp
+++ b/lib/tinykvm/memory.hpp
@@ -77,7 +77,7 @@ struct vMemory {
 	VirtualMem vmem() const;
 
 	[[noreturn]] static void memory_exception(const char*, uint64_t, uint64_t);
-	void record_cow_page(uint64_t addr, uint64_t entry);
+	void record_cow_leaf_user_page(uint64_t addr);
 	bool fork_reset(const Machine&, const MachineOptions&); // Returns true if a full reset was done
 	void fork_reset(const vMemory& other, const MachineOptions&);
 	static vMemory New(Machine&, const MachineOptions&, uint64_t phys, uint64_t safe, size_t size);


### PR DESCRIPTION
Most of the time spent in fork_reset is spent iterating over the page tables. For kvmserver with threads=1 I see a reduction from 280us to 135us for deno hello world and 900us to 735us for the Deno React benchmark.

The existing implementation always picked up page 0xffe00000 which had special flags. This is unrelated to this change but will remove since it appears to be unnecessary. See: https://github.com/varnish/tinykvm/blob/6af8ab6aeb494db045ed8e6516670bbc588c205f/lib/tinykvm/amd64/paging.cpp#L529

The MADV_FREE is also changed to MADV_DONTNEED which guarantees the page will be zeroed on subsequent access.