### PR TITLE
tests: auto-init Catch2 submodule in unit harness

### DIFF
--- a/tests/run_unit_tests.sh
+++ b/tests/run_unit_tests.sh
@@ -1,9 +1,23 @@
-FOLDER=build_unittests
-set -e
+#!/usr/bin/env bash
+set -euo pipefail
 
-mkdir -p $FOLDER
-pushd $FOLDER
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+FOLDER="${SCRIPT_DIR}/build_unittests"
+
+if [[ ! -f "${ROOT_DIR}/tests/Catch2/CMakeLists.txt" ]]; then
+	echo "Catch2 checkout missing; initializing tests/Catch2 submodule..."
+	git -C "${ROOT_DIR}" submodule update --init --recursive tests/Catch2
+fi
+
+if [[ ! -f "${ROOT_DIR}/tests/Catch2/CMakeLists.txt" ]]; then
+	echo "Failed to initialize tests/Catch2/CMakeLists.txt."
+	exit 1
+fi
+
+mkdir -p "${FOLDER}"
+pushd "${FOLDER}" >/dev/null
 cmake ../unit -DCMAKE_BUILD_TYPE=Debug
-make -j4
-ctest --verbose . $@
-popd
+cmake --build . -j4
+ctest --verbose "$@"
+popd >/dev/null


### PR DESCRIPTION
## Summary
- Auto-initialize the `tests/Catch2` submodule in `tests/run_unit_tests.sh` when missing.
- Keeps unit harness self-contained on fresh clones/worktrees.

## Why
- Prevents avoidable harness failures caused by missing submodule checkout.

## Validation
- `cd tests && bash run_unit_tests.sh -R test_basic`

## Depends on
- none
