### PR TITLE
elf: apply R_X86_64_RELATIVE addend semantics

### DIFF
--- a/lib/tinykvm/machine_elf.cpp
+++ b/lib/tinykvm/machine_elf.cpp
@@ -374,7 +374,7 @@ bool Machine::relocate_section(const char* section_name, const char* sym_section
 
 		const address_t addr = this->m_image_base + rela_addr[i].r_offset;
 		if (memory.safely_within(addr, sizeof(address_t))) {
-			*(address_t*) memory.safely_at(addr, sizeof(address_t)) = this->m_image_base + sym->st_value;
+			*(address_t*) memory.safely_at(addr, sizeof(address_t)) = this->m_image_base + rela_addr[i].r_addend;
 		} else {
 			if constexpr (VERBOSE_LOADER) {
 				printf("Relocation failed: %s\n", &m_binary[sym->st_name]);


### PR DESCRIPTION
## Summary
- Correct `R_X86_64_RELATIVE` relocation behavior to apply `base + addend` semantics.

## Why
- Required for correct dynamic loader/bootstrap relocation behavior.

## Validation
- `cd tests && bash run_unit_tests.sh -R test_elf`

## Depends on
- #67 (recommended)

## Stack Context
- Part of relocation runtime stack.
- Predecessor for #69.


## Test Evidence
- Date: 2026-04-02
- Branch-level validation source: phase14_audit baseline sweep
- Full unit harness: `cd tests && bash run_unit_tests.sh` -> 8/8 passed
- Integration tinytest lane: `(cd guest/tests && bash build.sh) && ./build/tinytest guest/tests/glibc_test` -> passed

### PR-Scoped Command
- `cd tests && bash run_unit_tests.sh -R test_elf`
- Stacked expectation: evaluate with #67; may be partial if reviewed in isolation
