### PR TITLE
guest: fix freestanding GCC malloc/free declarations

### DIFF
--- a/guest/src/crc32c.cpp
+++ b/guest/src/crc32c.cpp
@@ -1,5 +1,8 @@
 #include "api.hpp"
 
+#include <stdlib.h>
+extern "C" void* malloc(size_t);
+extern "C" void free(void*);
 #include <immintrin.h>
 
 inline bool ____is__aligned(const void* buffer, const int align) noexcept {

--- a/guest/src/guest.cpp
+++ b/guest/src/guest.cpp
@@ -32,6 +32,9 @@ struct Data {
 	size_t len;
 };
 
+#include <stdlib.h>
+extern "C" void* malloc(size_t);
+extern "C" void free(void*);
 #include <immintrin.h>
 PUBLIC(uint32_t empty(const Data& data))
 {


### PR DESCRIPTION
# PR B Draft: Guest Toolchain Compatibility Fix

## Summary

This PR fixes guest build compatibility for stricter freestanding C++ toolchains by addressing `malloc/free` declaration visibility in intrinsics-related translation units.

## What Changed

Files in this PR:

- `guest/src/guest.cpp`
- `guest/src/crc32c.cpp`

## Scope

- Build/toolchain compatibility only.
- No relocation policy or loader behavior changes.
- No functional feature expansion.

## Why

Recent toolchain behavior can fail guest builds due to declaration visibility rules. This patch restores build stability in that environment.

## Validation

- `cd guest && bash ./build.sh`

## Reviewer Ask

Please review this as an orthogonal maintenance fix independent of relocation semantics.
