### PR TITLE
arm64: flush guest stage-1 TLB after host-initiated copy-on-write

### DIFF
--- a/lib/tinykvm/arm64/paging.cpp
+++ b/lib/tinykvm/arm64/paging.cpp
@@ -105,6 +105,10 @@ static void split_l2_block(vMemory& memory, uint64_t& entry)
 		page.pmem[i] = page_desc(base + (i << 12), flags);
 	}
 	entry = (page.addr & DESC_ADDR_MASK) | DESC_TABLE | DESC_VALID;
+	// Block -> table is a break-before-make change: a cached 2MB block entry
+	// must be invalidated before the guest uses the new translation.
+	if (memory.machine.is_forked())
+		memory.pending_guest_tlb_flush = true;
 }
 
 static void cow_page(vMemory& memory, uint64_t addr, uint64_t& entry, uint64_t*& data,
@@ -128,6 +132,10 @@ static void cow_page(vMemory& memory, uint64_t addr, uint64_t& entry, uint64_t*&
 	}
 	entry = page.addr | (entry & (DESC_FLAGS_MASK & ~(DESC_CLONEABLE | DESC_AP_RO))) | DESC_VALID | DESC_PAGE;
 	data = page.pmem;
+	// Repointing a (possibly cached read-only) leaf to a private copy: the
+	// guest's stale translation must be invalidated before it reads here.
+	if (memory.machine.is_forked())
+		memory.pending_guest_tlb_flush = true;
 	if (entry & DESC_AP_USER)
 		memory.record_cow_leaf_user_page(addr);
 }
@@ -490,6 +498,7 @@ WritablePage writable_page_at(vMemory& memory, uint64_t addr, uint64_t verify_fl
 				| (e3 & (DESC_FLAGS_MASK & ~(DESC_CLONEABLE | DESC_AP_RO)))
 				| DESC_VALID | DESC_PAGE;
 			data = page.pmem;
+			memory.pending_guest_tlb_flush = true;
 			if (e3 & DESC_AP_USER)
 				memory.record_cow_leaf_user_page(addr);
 		} else {

--- a/lib/tinykvm/arm64/vcpu_run.cpp
+++ b/lib/tinykvm/arm64/vcpu_run.cpp
@@ -51,6 +51,64 @@ static uint64_t get_sysreg(int fd, uint64_t id)
 	return value;
 }
 
+static void set_one_reg_u64(int fd, uint64_t id, uint64_t value)
+{
+	struct kvm_one_reg reg {
+		.id = id,
+		.addr = (uint64_t)&value,
+	};
+	if (ioctl(fd, KVM_SET_ONE_REG, &reg) < 0) {
+		throw MachineException("KVM_SET_ONE_REG failed", errno);
+	}
+}
+
+static uint64_t core_reg_id(uint64_t reg)
+{
+	return KVM_REG_ARM64 | KVM_REG_SIZE_U64 | KVM_REG_ARM_CORE | reg;
+}
+
+/* Invalidate the (forked) guest's stage-1 TLB by running the EL1 TLB-flush
+   stub for one entry. The host cannot invalidate the guest's stage-1 TLB
+   through KVM, and -- unlike a guest data abort, whose sync vector runs
+   `tlbi vaae1` for the faulting VA before eret'ing -- a host-initiated
+   copy-on-write (e.g. delivering syscall results into a guest buffer) leaves
+   no guest-side invalidation. A stale block/read-only entry would then shadow
+   the freshly CoW'd page and the guest reads pre-CoW data.
+
+   Done with raw ioctls rather than cpu.run(): run() resets `stopped` and tears
+   down the timeout timer, which must not happen mid run-loop (the likely flaw
+   in earlier full-flush attempts that "had no effect"). Only PC/PSTATE/x9 are
+   clobbered by the stub; save and restore just those. */
+void vCPU::flush_guest_tlb()
+{
+	const uint64_t PC_ID = core_reg_id(KVM_REG_ARM_CORE_REG(regs.pc));
+	const uint64_t PSTATE_ID = core_reg_id(KVM_REG_ARM_CORE_REG(regs.pstate));
+	const uint64_t X9_ID = core_reg_id(KVM_REG_ARM_CORE_REG(regs.regs)
+		+ 9 * sizeof(__u64) / sizeof(__u32));
+
+	this->flush_registers();
+	const uint64_t saved_pc = get_sysreg(this->fd, PC_ID);
+	const uint64_t saved_pstate = get_sysreg(this->fd, PSTATE_ID);
+	const uint64_t saved_x9 = get_sysreg(this->fd, X9_ID);
+
+	set_one_reg_u64(this->fd, PC_ID, TLB_FLUSH_ADDR);
+	set_one_reg_u64(this->fd, PSTATE_ID, 0x5 /* EL1h */ | 0x3C0 /* DAIF masked */);
+	if (ioctl(this->fd, KVM_RUN, 0) < 0) {
+		Machine::machine_exception("KVM_RUN (guest TLB flush) failed", errno);
+	}
+	/* The stub's stop-MMIO store leaves a PC increment that KVM commits on the
+	   next entry; consume it now (against the stub PC) so the real resume does
+	   not skip its first instruction -- see the stop-MMIO handler below. */
+	this->kvm_run->immediate_exit = 1;
+	ioctl(this->fd, KVM_RUN, 0);
+	this->kvm_run->immediate_exit = 0;
+
+	set_one_reg_u64(this->fd, PC_ID, saved_pc);
+	set_one_reg_u64(this->fd, PSTATE_ID, saved_pstate);
+	set_one_reg_u64(this->fd, X9_ID, saved_x9);
+	this->invalidate_register_cache();
+}
+
 static bool handle_cow_data_abort(vCPU& cpu)
 {
 	const uint64_t ESR_EL1 = sys_reg_id(3, 0, 5, 2, 0);
@@ -72,6 +130,11 @@ static bool handle_cow_data_abort(vCPU& cpu)
 	ScopedProfiler<MachineProfiling::PageFault> prof(cpu.machine().profiling());
 	cpu.machine().main_memory().get_writable_page(far & ~PageMask(), 1ULL, false, true);
 	cpu.last_fault_address = far;
+	/* This CoW was driven by a guest fault: the sync vector invalidates the
+	   faulting VA itself on return (tlbi vaae1), so no host-side flush is owed.
+	   Clear the flag the CoW just set so the run loop does not redundantly flush
+	   the whole TLB on resume. */
+	cpu.machine().main_memory().pending_guest_tlb_flush = false;
 	return true;
 }
 
@@ -128,6 +191,15 @@ void vCPU::disable_timer()
 
 long vCPU::run_once()
 {
+	/* A host-initiated copy-on-write (e.g. delivering syscall results into a
+	   guest buffer, frequently via a host-side Machine::system_call() that
+	   bypasses this run loop) rewrote this fork's page tables with no
+	   guest-side TLB invalidation. Flush the stale stage-1 entry before
+	   entering, or the guest reads pre-CoW data. */
+	if (machine().is_forked() && machine().memory.pending_guest_tlb_flush) {
+		machine().memory.pending_guest_tlb_flush = false;
+		this->flush_guest_tlb();
+	}
 	int result;
 	{
 		ScopedProfiler<MachineProfiling::VCpuRun> prof(machine().profiling());

--- a/lib/tinykvm/memory.hpp
+++ b/lib/tinykvm/memory.hpp
@@ -30,6 +30,16 @@ struct vMemory {
 	/* Counter for the number of pages that have been unlocked
 	   in the main memory. */
 	size_t unlocked_pages = 0;
+	/* Set by writable_page_at() when a host-initiated copy-on-write structurally
+	   rewrites a forked guest's translation (block split or leaf repoint). Such
+	   a write -- e.g. delivering syscall results into a guest buffer, often via
+	   a host-side Machine::system_call() outside the run loop -- has no
+	   guest-side TLB invalidation (unlike a guest data abort, whose sync vector
+	   runs `tlbi` for the faulting VA on return). The ARM64 run loop flushes the
+	   guest's stage-1 TLB before the next entry whenever this is set, or a stale
+	   block/read-only entry would shadow the freshly CoW'd page. Cleared on a
+	   guest data abort (the guest self-heals that VA). */
+	bool pending_guest_tlb_flush = false;
 	/* Linear memory */
 	char*  ptr;
 	size_t size;

--- a/lib/tinykvm/vcpu.hpp
+++ b/lib/tinykvm/vcpu.hpp
@@ -18,6 +18,10 @@ namespace tinykvm
 #if defined(TINYKVM_ARCH_ARM64)
 		void flush_registers() const;
 		void invalidate_register_cache() const;
+		/* Invalidate this (forked) guest's stage-1 TLB before the next entry,
+		   after the host rewrote its page tables via a host-initiated
+		   copy-on-write. Runs the EL1 TLB-flush stub for one entry. */
+		void flush_guest_tlb();
 #endif
 		tinykvm_fpuregs fpu_registers() const;
 		void set_fpu_registers(const struct tinykvm_fpuregs &);

--- a/tests/unit/arm64_minimal.cpp
+++ b/tests/unit/arm64_minimal.cpp
@@ -52,6 +52,21 @@ static const std::array<uint32_t, 3> cntvct_guest {
 	0xF9000060, // str x0, [x3]   (STOP MMIO -> exit)
 };
 
+// Two phases, run as two separate guest entries with a host-initiated
+// copy-on-write in between.
+static const std::array<uint32_t, 6> block_cow_guest {
+	// phase 1 @ +0: read page A to cache the 2MB block translation (which also
+	// covers page B), then stop so the host can CoW page B.
+	0xF9400025, // ldr x5, [x1]   (x1 = page A, in the block)
+	0xF90000C5, // str x5, [x6]   (x6 = DATA_ADDR: report A)
+	0xF900007F, // str xzr, [x3]  (x3 = STOP MMIO -> exit run 1)
+	// phase 2 @ +12: read page B, which the host split out of the block and
+	// copy-on-wrote while the guest held the stale block translation.
+	0xF9400045, // ldr x5, [x2]   (x2 = page B)
+	0xF90000C5, // str x5, [x6]   (report B)
+	0xF900007F, // str xzr, [x3]  (STOP MMIO -> exit run 2)
+};
+
 static bool contains_page(const std::vector<std::pair<uint64_t, uint64_t>>& pages,
 	uint64_t addr)
 {
@@ -559,6 +574,122 @@ TEST_CASE("ARM64 read-only file-backed protections stay EL0-executable", "[arm64
 		uxn_set = (entry & DESC_UXN) != 0;
 	});
 	REQUIRE(!uxn_set);
+}
+
+TEST_CASE("ARM64 host CoW after guest cached a 2MB block translation", "[arm64]")
+{
+	require_arm64_kvm();
+
+	const std::vector<uint8_t> empty_binary;
+	const tinykvm::MachineOptions options {
+		.max_mem = 8ull << 20,
+		.max_cow_mem = 4u << 20,
+		.split_hugepages = true,
+	};
+
+	const uint64_t block_addr = 1ULL << 21;          // 0x200000: a 2MB identity block
+	const uint64_t page_a = block_addr;              // 0x200000
+	const uint64_t page_b = block_addr + 0x1000;     // 0x201000: same block, other 4KB page
+	const uint64_t master_b = 0x1111111111111111ull;
+
+	tinykvm::Machine master {empty_binary, options};
+	master.copy_to_guest(CODE_ADDR, block_cow_guest.data(),
+		block_cow_guest.size() * sizeof(block_cow_guest[0]));
+	master.copy_to_guest(page_b, &master_b, sizeof(master_b));
+	master.prepare_copy_on_write(options.max_cow_mem);
+
+	tinykvm::Machine fork {master, options};
+
+	// Run 1: the guest reads page A, caching the read-only 2MB block translation
+	// that also covers page B.
+	auto regs = fork.registers();
+	regs.pc = CODE_ADDR;
+	regs.sp = STACK_ADDR;
+	regs.pstate = 0x3c0;
+	regs.regs[1] = page_a;
+	regs.regs[3] = tinykvm::ARM64_STOP_MMIO_ADDR;
+	regs.regs[6] = DATA_ADDR;
+	fork.set_registers(regs);
+	fork.run(1.0f);
+	REQUIRE(fork.stopped());
+
+	// Host-initiated CoW: writing page B splits the 2MB block into 4KB pages and
+	// copies page B to a fresh bank page. No guest fault occurs, so nothing
+	// invalidates the stale 2MB block entry the guest cached in run 1.
+	const uint64_t host_b = 0x2222222222222222ull;
+	fork.copy_to_guest(page_b, &host_b, sizeof(host_b));
+
+	// Host-side translation through the fork's own page tables is correct.
+	uint64_t host_view = 0;
+	fork.copy_from_guest(&host_view, page_b, sizeof(host_view));
+	REQUIRE(host_view == host_b);
+
+	// Run 2: the guest reads page B. It must observe the host's write, not the
+	// stale master content reachable through the cached block translation.
+	regs = fork.registers();
+	regs.pc = CODE_ADDR + 3 * sizeof(uint32_t);
+	regs.sp = STACK_ADDR;
+	regs.pstate = 0x3c0;
+	regs.regs[2] = page_b;
+	regs.regs[3] = tinykvm::ARM64_STOP_MMIO_ADDR;
+	regs.regs[6] = DATA_ADDR;
+	fork.set_registers(regs);
+	fork.run(1.0f);
+	REQUIRE(fork.stopped());
+
+	uint64_t observed = 0;
+	fork.copy_from_guest(&observed, DATA_ADDR, sizeof(observed));
+	REQUIRE(observed == host_b);
+}
+
+TEST_CASE("ARM64 host CoW on a fresh fork before the guest runs", "[arm64]")
+{
+	require_arm64_kvm();
+
+	const std::vector<uint8_t> empty_binary;
+	const tinykvm::MachineOptions options {
+		.max_mem = 8ull << 20,
+		.max_cow_mem = 4u << 20,
+		.split_hugepages = true,
+	};
+
+	const uint64_t block_addr = 1ULL << 21;
+	const uint64_t page_b = block_addr + 0x1000;
+	const uint64_t master_b = 0x1111111111111111ull;
+
+	tinykvm::Machine master {empty_binary, options};
+	master.copy_to_guest(CODE_ADDR, block_cow_guest.data(),
+		block_cow_guest.size() * sizeof(block_cow_guest[0]));
+	master.copy_to_guest(page_b, &master_b, sizeof(master_b));
+	master.prepare_copy_on_write(options.max_cow_mem);
+
+	// Fresh fork: its TLB was flushed by setup_cow_mode and the guest has not
+	// run, mirroring a warm fork serving its very first turn.
+	tinykvm::Machine fork {master, options};
+
+	// Host-initiated CoW (splits the block, copies page B) before any guest run.
+	const uint64_t host_b = 0x2222222222222222ull;
+	fork.copy_to_guest(page_b, &host_b, sizeof(host_b));
+
+	uint64_t host_view = 0;
+	fork.copy_from_guest(&host_view, page_b, sizeof(host_view));
+	REQUIRE(host_view == host_b);
+
+	// The guest's very first instruction reads page B.
+	auto regs = fork.registers();
+	regs.pc = CODE_ADDR + 3 * sizeof(uint32_t);  // phase 2
+	regs.sp = STACK_ADDR;
+	regs.pstate = 0x3c0;
+	regs.regs[2] = page_b;
+	regs.regs[3] = tinykvm::ARM64_STOP_MMIO_ADDR;
+	regs.regs[6] = DATA_ADDR;
+	fork.set_registers(regs);
+	fork.run(1.0f);
+	REQUIRE(fork.stopped());
+
+	uint64_t observed = 0;
+	fork.copy_from_guest(&observed, DATA_ADDR, sizeof(observed));
+	REQUIRE(observed == host_b);
 }
 
 TEST_CASE("ARM64 EL0 reads cntvct_el0 without trapping", "[arm64]")


### PR DESCRIPTION
## Problem

On ARM64, a host-initiated copy-on-write — e.g. delivering syscall results into a guest buffer via `copy_to_guest`, often through a host-side `Machine::system_call()` outside the run loop — rewrites a forked guest's page tables (a 2 MB block split and/or a leaf repoint) with **no guest-side TLB invalidation**.

Unlike a guest data abort, whose sync vector runs `tlbi vaae1` for the faulting VA before returning, the host path left the stale read-only / 2 MB-block translation cached. A guest that had already walked the block then read **pre-CoW data** through the stale entry (silent wrong data, or a fault). This showed up on 16 KiB-page hosts (Asahi) serving warm CoW forks.

## Fix

- `writable_page_at` records that a fork's tables were structurally rewritten via `vMemory::pending_guest_tlb_flush`.
- The ARM64 run loop runs an EL1 TLB-flush stub (`vCPU::flush_guest_tlb`) before the next guest entry when the flag is set. It uses raw ioctls rather than `cpu.run()` so it does not reset `stopped` / the timeout timer mid run-loop.
- The flag is cleared on a guest data abort, which already self-heals the faulting VA via the sync vector — so guest-initiated CoW takes no extra flush.

## Tests

`tests/unit/arm64_minimal.cpp`:
- "host CoW after guest cached a 2MB block translation" — deterministically reads stale data **without** the flush, correct with it.
- "host CoW on a fresh fork before the guest runs" — guards the fresh-fork path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)