### PR TITLE
machine: snapshot master FPU at prepare time for cross-process forks

### DIFF
--- a/lib/tinykvm/arm64/vcpu.cpp
+++ b/lib/tinykvm/arm64/vcpu.cpp
@@ -434,6 +434,7 @@ void Machine::prepare_copy_on_write(size_t max_work_mem,
 	uint64_t shared_memory_boundary, bool split_accessed_hugepages)
 {
 	this->m_prepped = true;
+	this->m_prepared_fpu_regs = this->fpu_registers();
 	if (shared_memory_boundary == 0)
 		shared_memory_boundary = UINT64_MAX;
 

--- a/lib/tinykvm/machine.cpp
+++ b/lib/tinykvm/machine.cpp
@@ -168,10 +168,14 @@ Machine::Machine(const Machine& other, const MachineOptions& options)
 		m_fds->reset_to(*other.m_fds);
 	}
 
-	/* Copy register state from the master machine */
+	/* Copy register state from the master machine. FPU state comes from the
+	   master's prepare-time snapshot rather than a live KVM_GET_FPU: when this
+	   fork is constructed from a master inherited over fork(), the master's
+	   vCPU fd is not ioctl-able from this process and KVM_GET_FPU fails with
+	   -EIO. See Machine::prepared_fpu_registers(). */
 	auto& m_regs = other.registers();
 	this->set_registers(m_regs);
-	this->set_fpu_registers(other.fpu_registers());
+	this->set_fpu_registers(other.prepared_fpu_registers());
 }
 
 __attribute__ ((cold))
@@ -288,10 +292,11 @@ bool Machine::reset_to(const Machine& other, const MachineOptions& options)
 #endif
 
 	if (options.reset_copy_all_registers) {
-		/* Copy register state from the master machine */
+		/* Copy register state from the master machine (FPU from the master's
+		   prepare-time snapshot; see the fork constructor). */
 		auto& m_regs = other.registers();
 		this->set_registers(m_regs);
-		this->set_fpu_registers(other.fpu_registers());
+		this->set_fpu_registers(other.prepared_fpu_registers());
 	}
 	if (options.reset_enter_usermode) {
 		/* Enforce usermode (default). This will crash guests

--- a/lib/tinykvm/machine.hpp
+++ b/lib/tinykvm/machine.hpp
@@ -142,6 +142,18 @@ struct Machine
 	void set_registers(const tinykvm_regs&);
 	tinykvm_fpuregs fpu_registers() const;
 	void set_fpu_registers(const tinykvm_fpuregs&);
+	/* FPU state snapshotted by prepare_copy_on_write(). Fork construction and
+	   fork reset read this instead of issuing KVM_GET_FPU against the master's
+	   vCPU, so both remain usable from a process that cannot ioctl the master's
+	   fds -- e.g. a child that inherited the master over fork() and is building
+	   its own VM from the master's copy-on-write memory (KVM vCPU ioctls require
+	   the caller's mm to be the VM-creating mm). Requires a prepared master: the
+	   snapshot is only valid because the master is frozen after prepare and is
+	   never run again, so it equals a live KVM_GET_FPU at fork time. */
+	const tinykvm_fpuregs& prepared_fpu_registers() const noexcept {
+		assert(m_prepped && "prepared_fpu_registers() requires prepare_copy_on_write()");
+		return m_prepared_fpu_regs;
+	}
 	const kvm_sregs& get_special_registers() const;
 	void set_special_registers(const kvm_sregs&);
 	std::pair<__u64, __u64> get_fsgs() const;
@@ -391,6 +403,8 @@ private:
 	bool  m_verbose_mmap_syscalls = false;
 	bool  m_verbose_thread_syscalls = false;
 	void* m_userdata = nullptr;
+	/* See prepared_fpu_registers(). */
+	tinykvm_fpuregs m_prepared_fpu_regs {};
 
 	std::string_view m_binary;
 

--- a/lib/tinykvm/vcpu.cpp
+++ b/lib/tinykvm/vcpu.cpp
@@ -22,6 +22,16 @@
 extern "C" int close(int);
 extern "C" void tinykvm_timer_signal_handler(int);
 #define TINYKVM_USE_SYNCED_SREGS 1
+/* Constructing or resetting a fork from a master inherited over fork() requires
+   that reading the master's registers never ioctls the master's vCPU fd, which
+   the child process cannot use. With synced sregs, get_special_registers()
+   reads the mmap'd kvm_run page instead of KVM_GET_SREGS; FPU is served from
+   the prepare-time snapshot (Machine::prepared_fpu_registers()). If this is
+   ever disabled, get_special_registers() reverts to KVM_GET_SREGS and
+   cross-process fork construction breaks with -EIO. */
+#if !TINYKVM_USE_SYNCED_SREGS
+#error "TINYKVM_USE_SYNCED_SREGS must be enabled for cross-process fork construction"
+#endif
 
 #ifndef SYS_gettid
 #error "SYS_gettid unavailable on this system"
@@ -420,6 +430,13 @@ void Machine::prepare_copy_on_write(size_t max_work_mem,
 	uint64_t shared_memory_boundary, bool split_accessed_hugepages)
 {
 	this->m_prepped = true;
+
+	/* Snapshot FPU state to userspace while this master's vCPU fd is still
+	   ours to ioctl. Fork construction and fork reset consume the snapshot via
+	   prepared_fpu_registers(), which keeps both usable from a process that
+	   inherited this master over fork(). The master is frozen hereafter, so the
+	   snapshot stays equal to a live KVM_GET_FPU. */
+	this->m_prepared_fpu_regs = this->fpu_registers();
 
 	/* Make each writable page read-only, causing page fault.
 	   any page after the @shared_memory_boundary is untouched,

--- a/tests/unit/arm64_minimal.cpp
+++ b/tests/unit/arm64_minimal.cpp
@@ -82,6 +82,15 @@ static void require_arm64_kvm()
 	}
 }
 
+static void require_fpu_prefix(const tinykvm::tinykvm_arm64fpuregs& expected,
+	const tinykvm::tinykvm_arm64fpuregs& actual)
+{
+	for (size_t i = 0; i < 64; i++) {
+		INFO("FP/SIMD byte " << i);
+		REQUIRE(actual.storage[i] == expected.storage[i]);
+	}
+}
+
 TEST_CASE("ARM64 raw guest exits through TinyKVM MMIO ABI", "[arm64]")
 {
 	require_arm64_kvm();
@@ -183,6 +192,33 @@ TEST_CASE("ARM64 copy_to_guest preserves source when zeroes hint is set", "[arm6
 	char buffer[5] {};
 	machine.copy_from_guest(buffer, addr, sizeof(buffer));
 	REQUIRE(std::string_view(buffer, sizeof(buffer)) == std::string_view("tiny\0", 5));
+}
+
+TEST_CASE("ARM64 fork/reset preserves prepared FP/SIMD state", "[arm64]")
+{
+	require_arm64_kvm();
+
+	const std::vector<uint8_t> empty_binary;
+	const tinykvm::MachineOptions options {
+		.max_mem = MAX_MEMORY,
+		.max_cow_mem = 2u << 20,
+		.split_hugepages = true,
+	};
+
+	tinykvm::Machine master {empty_binary, options};
+	tinykvm::tinykvm_arm64fpuregs expected {};
+	for (size_t i = 0; i < 64; i++)
+		expected.storage[i] = static_cast<uint8_t>(0xa0 + i);
+	master.set_fpu_registers(expected);
+	master.prepare_copy_on_write(options.max_cow_mem);
+
+	tinykvm::Machine fork {master, options};
+	require_fpu_prefix(expected, fork.fpu_registers());
+
+	tinykvm::tinykvm_arm64fpuregs zero {};
+	fork.set_fpu_registers(zero);
+	fork.reset_to(master, options);
+	require_fpu_prefix(expected, fork.fpu_registers());
 }
 
 TEST_CASE("ARM64 fork uses copy-on-write for guest stores", "[arm64]")


### PR DESCRIPTION
## Problem

Fork construction (`Machine(const Machine&, const MachineOptions&)`) and fork
reset (`reset_to`) copy the master's FPU state with a live `KVM_GET_FPU` against
the master's vCPU fd. That only works in the process that created the VM: KVM
vCPU ioctls require the caller's `mm` to be the VM-creating `mm`. A child that
inherited the master over `fork()` and builds its own VM from the master's
copy-on-write memory gets `-EIO` on that ioctl and cannot construct a fork.

## Change

Snapshot the master's FPU registers into the `Machine` at
`prepare_copy_on_write()` time — while the master's vCPU fd is still ioctl-able —
and have fork construction and `reset_to()` read that snapshot via the new
`prepared_fpu_registers()` accessor instead of a live `KVM_GET_FPU`.

- **Behavior-preserving for the in-process case.** The master is frozen after
  prepare and never runs again, so the snapshot is bit-identical to what a live
  `KVM_GET_FPU` would return at fork time.
- **Precondition made explicit.** `prepared_fpu_registers()` asserts `m_prepped`,
  and the snapshot is only taken in `prepare_copy_on_write()`.
- **sregs guard.** The special-registers half of cross-process safety is already
  covered by `TINYKVM_USE_SYNCED_SREGS` (reads the mmap'd `kvm_run` page instead
  of `KVM_GET_SREGS`). Added a `#error` guard so disabling that define can't
  silently reintroduce the `-EIO` on the sregs path.

Cost is one `tinykvm_fpuregs` (~fxsave/xsave layout) per `Machine`, always.

## Testing

- `cmake --build build` clean (only pre-existing sign-compare warnings in
  `src/tests.cpp`).
- `tests/run_unit_tests.sh`: `test_reset` passes 46/47 assertions. The one
  failing assertion (`output_is_hello_world`) also fails identically on `master`
  — it comes from a test that compiles a static guest ELF with `gcc` at runtime
  and is environmental on my host, unrelated to this change. Same for
  `test_tegridy`. All other suites pass.

## Motivation

Enables a process-per-VM model where a single-threaded zygote `fork()`s worker
processes that each construct a TinyKVM fork from a master inherited over
`fork()` — isolating tenant workloads in separate address spaces / jailed
processes rather than threads.