### PR TITLE
Fix fork reset mmap source

### DIFF
--- a/lib/tinykvm/memory.cpp
+++ b/lib/tinykvm/memory.cpp
@@ -223,9 +223,19 @@ bool vMemory::fork_reset(const Machine& main_vm, const MachineOptions& options)
 				const uint64_t vbase = addr & ~(page_size - 1);
 				for (size_t e = 0; e < page_size / granule; e++) {
 					auto* dest = (uint64_t*)our_page + e * (granule / sizeof(uint64_t));
-					auto* master_page = tinykvm::readable_page_at(
-						main_vm.main_memory(), vbase + e * granule, flags);
-					page_duplicate(dest, (const uint64_t*)master_page);
+					try {
+						auto* master_page = tinykvm::readable_page_at(
+							main_vm.main_memory(), vbase + e * granule, flags);
+						page_duplicate(dest, (const uint64_t*)master_page);
+					} catch (const MemoryException&) {
+						// The master (frozen since fork) has no present page
+						// here, so this was an unpresent copy-on-write entry:
+						// a fresh fork writing to it gets a zeroed page (no
+						// DIRTY bit -> zero_and_update_entry). Zeroing
+						// restores fresh-fork semantics without demoting the
+						// whole reset to the full bank-reset fallback below.
+						page_memzero(dest);
+					}
 				}
 			}, false);
 		}

--- a/lib/tinykvm/memory.cpp
+++ b/lib/tinykvm/memory.cpp
@@ -196,17 +196,37 @@ bool vMemory::fork_reset(const Machine& main_vm, const MachineOptions& options)
 		// Restore the original memory from the master VM.
 		try {
 		for (const uint64_t addr : cow_written_pages) {
-			tinykvm::page_at(*this, addr, [&](uint64_t addr, uint64_t& entry, uint64_t page_size) {
+			tinykvm::page_at(*this, addr, [&](uint64_t cb_addr, uint64_t& entry, uint64_t page_size) {
 				const uint64_t bank_addr = entry & tinykvm::paging_address_mask();
+				(void)cb_addr;
 				//fprintf(stderr, "Copying virtual page %016lx from physical %016lx with size %lu\n",
 				//	addr, bank_addr, page_size);
 
 				// This is a writable page, we will copy it using the "real"
 				// address from the master VM.
 				auto* our_page = this->safely_at(bank_addr, page_size);
-				// Find the page in the main VM
-				page_duplicate((uint64_t*)our_page,
-					(const uint64_t*)main_vm.main_memory().safely_at(addr, page_size));
+				// Find the page in the main VM *through its page tables*.
+				// Only main memory is identity-mapped; the mmap physical
+				// region (MMAP_PHYS_BASE) is not, so reading the source with
+				// main_memory().safely_at(virtual) would silently copy a
+				// wrong (typically zero) page into the fork for any recorded
+				// address backed by mmap-allocated physical pages.
+				// A 2MB leaf is restored one 4K page at a time: the master
+				// may hold 4K pages (or a huge page) there, and per-page
+				// resolution covers both.
+#ifdef TINYKVM_ARCH_AMD64
+				constexpr uint64_t flags = PDE64_PRESENT;
+#else
+				constexpr uint64_t flags = 1ULL; // DESC_VALID
+#endif
+				constexpr uint64_t granule = vMemory::PageSize();
+				const uint64_t vbase = addr & ~(page_size - 1);
+				for (size_t e = 0; e < page_size / granule; e++) {
+					auto* dest = (uint64_t*)our_page + e * (granule / sizeof(uint64_t));
+					auto* master_page = tinykvm::readable_page_at(
+						main_vm.main_memory(), vbase + e * granule, flags);
+					page_duplicate(dest, (const uint64_t*)master_page);
+				}
 			}, false);
 		}
 		return false;


### PR DESCRIPTION
I ran into an issue with Python 3.14. First attempt at a fix had some potential performance on a throw, that is addressed in the second commit.

The `reset_keep_all_work_memory=true` fast recycle path in `vMemory::fork_reset`
restores each dirty bank page with:

    page_duplicate((uint64_t*)our_page,
        (const uint64_t*)main_vm.main_memory().safely_at(addr, page_size));

`safely_at(virtual_addr)` treats the recorded guest-virtual address as a
physical one. That only holds for identity-mapped main memory. Pages backed by
the mmap physical region (`MMAP_PHYS_BASE`) are not identity-mapped, so for
every recorded page living there the copy sourced an unpopulated main-memory
page — silently writing zeros into the fork's bank page on every reset.

The 2MB-leaf case was doubly wrong: the lambda parameter shadowed the loop
variable, so the copy source was the bank's *physical* block address rather
than any guest virtual address.

### Observed impact

CPython 3.14 places `PyInterpreterState` on mmap-region pages. A recycled fork
reads `interp->obmalloc` as NULL on its next turn and faults in obmalloc's
`arena_map_get` — deterministically, every second call (fresh mint OK →
recycled fork faults → retire/remint repeats). CPython 3.12 survives only
because nothing it reads back post-reset happens to live on mmap-backed pages;
the copy-back corrupts them there too.
page-table walk and from the vCPU (not stale TLB); the master's true page
(PTE → mmap region) holds the pointer while the identity read returns zeros;
and `reset_keep_all_work_memory=false` makes the failures vanish.

## Fix

**Commit 1** — resolve each 4K source page through the master's page tables
with `readable_page_at`, which handles identity-mapped and mmap-backed
physical pages alike and returns the correct 4K segment when the master holds
a 2MB huge page. A 2MB fork leaf is restored one 4K page at a time, covering
masters with either page size underneath. The loop is arch-neutral (the arm64
backend has its own `readable_page_at`); the PRESENT/VALID flag ifdef follows
the existing pattern in this file.

**Commit 2** — `readable_page_at` throws when the master's entry is unpresent,
and unpresent-but-cloneable entries are real (anonymous memory the master
mapped but never touched). Before this commit, one such recorded page made
every `fork_reset` throw mid-loop into the full bank-reset fallback — silently
and permanently demoting that fork off the fast recycle path. The master is
frozen after fork, so an entry unpresent at reset time was unpresent at write
time — exactly the unpresent-CoW case in `writable_page_at`, where a fresh
fork gets a zeroed page (`zero_and_update_entry`, no DIRTY bit). Catching per
page and `page_memzero`-ing the destination reproduces fresh-fork semantics
bit-for-bit; the happy path pays nothing and the outer catch remains the last
resort for genuinely unexpected failures.