### PR TITLE
linux: close four path- and fd-policy gaps in the syscall handlers

### DIFF
--- a/lib/tinykvm/linux/system_calls.cpp
+++ b/lib/tinykvm/linux/system_calls.cpp
@@ -1130,22 +1130,32 @@ void Machine::setup_linux_system_calls(bool unsafe_syscalls)
 			auto& regs = cpu.registers();
 			// int setsockopt(int sockfd, int level, int optname,
 			//                const void *optval, socklen_t optlen);
-			const int fd = cpu.machine().fds().translate(regs.sysarg(0));
 			const int level = regs.sysarg(1);
 			const int optname = regs.sysarg(2);
 			const uint64_t g_optval = regs.sysarg(3);
 			const size_t optlen = regs.sysarg(4);
-			std::array<uint8_t, 256> optval;
-			if (UNLIKELY(optlen > optval.size()))
-			{
-				regs.sysret() = -EINVAL;
-			} else {
-				cpu.machine().copy_from_guest(optval.data(), g_optval, optlen);
-				if (setsockopt(fd, level, optname, optval.data(), optlen) < 0) {
-					regs.sysret() = -errno;
-				} else {
-					regs.sysret() = 0;
+			int fd = -1;
+			try {
+				// Mutates the host socket, so it needs the writable variant.
+				fd = cpu.machine().fds().translate_writable_vfd(regs.sysarg(0));
+				std::array<uint8_t, 256> optval;
+				if (UNLIKELY(fd < 0))
+				{
+					regs.sysret() = -EBADF;
 				}
+				else if (UNLIKELY(optlen > optval.size()))
+				{
+					regs.sysret() = -EINVAL;
+				} else {
+					cpu.machine().copy_from_guest(optval.data(), g_optval, optlen);
+					if (setsockopt(fd, level, optname, optval.data(), optlen) < 0) {
+						regs.sysret() = -errno;
+					} else {
+						regs.sysret() = 0;
+					}
+				}
+			} catch (...) {
+				regs.sysret() = -EBADF;
 			}
 			cpu.set_registers(regs);
 			SYSPRINT("setsockopt(fd=%d, level=%d, optname=%d, optval=0x%lX, optlen=%zu) = %lld\n",
@@ -1825,7 +1835,7 @@ void Machine::setup_linux_system_calls(bool unsafe_syscalls)
 				}
 				else if (cmd == F_SETFL)
 				{
-					const int writable_fd = cpu.machine().fds().translate(vfd);
+					const int writable_fd = cpu.machine().fds().translate_writable_vfd(vfd);
 					const int allowed_flags = O_NONBLOCK;
 					const int flags = regs.sysarg(2) & allowed_flags;
 					if (fcntl(writable_fd, F_SETFL, flags) < 0)
@@ -2102,34 +2112,45 @@ void Machine::setup_linux_system_calls(bool unsafe_syscalls)
 			auto& regs = cpu.registers();
 			// int unlinkat(int dirfd, const char *pathname, int flags);
 			const int vdirfd = regs.sysarg(0);
-			const int flags = regs.sysarg(1) | AT_SYMLINK_NOFOLLOW;
-			const uint64_t g_path = regs.sysarg(2);
+			const uint64_t g_path = regs.sysarg(1);
+			// AT_REMOVEDIR is the only flag unlinkat accepts.
+			const int flags = regs.sysarg(2) & AT_REMOVEDIR;
 			std::string path;
-			// Check if the path is writable (path can be modified)
-			if (cpu.machine().fds().is_writable_path(path))
-			{
-				int dirfd = cpu.machine().fds().current_working_directory_fd();
-				if (vdirfd != AT_FDCWD)
-				{
-					dirfd = cpu.machine().fds().translate_writable_vfd(vdirfd);
-				}
-
+			try {
 				if (g_path != 0x0)
 				{
 					path = cpu.machine().memcstring(g_path, PATH_MAX);
 				}
 
-				// Unlink the file, relative to the dirfd
-				if (unlinkat(dirfd, path.c_str(), flags) < 0) {
-					regs.sysret() = -errno;
+				if (path.empty())
+				{
+					// Linux has no AT_EMPTY_PATH for unlinkat, and the
+					// policy layer has nothing to decide about "".
+					regs.sysret() = -ENOENT;
 				}
-				else {
-					regs.sysret() = 0;
+				// Check if the path is writable (path can be modified)
+				else if (cpu.machine().fds().is_writable_path(path))
+				{
+					int dirfd = cpu.machine().fds().current_working_directory_fd();
+					if (vdirfd != AT_FDCWD)
+					{
+						dirfd = cpu.machine().fds().translate_writable_vfd(vdirfd);
+					}
+
+					// Unlink the file, relative to the dirfd
+					if (unlinkat(dirfd, path.c_str(), flags) < 0) {
+						regs.sysret() = -errno;
+					}
+					else {
+						regs.sysret() = 0;
+					}
 				}
-			}
-			else
-			{
-				regs.sysret() = -EPERM;
+				else
+				{
+					regs.sysret() = -EPERM;
+				}
+			} catch (...) {
+				regs.sysret() = -EBADF;
 			}
 			cpu.set_registers(regs);
 			SYSPRINT("unlinkat(%d, %s (0x%llX), %d) = %lld\n",
@@ -2413,6 +2434,21 @@ void Machine::setup_linux_system_calls(bool unsafe_syscalls)
 					int pfd = cpu.machine().fds().current_working_directory_fd();
 					if (vfd != AT_FDCWD) {
 						pfd = cpu.machine().fds().translate(vfd);
+					}
+					/* O_CREAT/O_TRUNC/O_APPEND mutate the host file, but only
+					   the readable-path policy is consulted on this branch.
+					   Deny rather than silently dropping the bits: may_open()
+					   adds MAY_WRITE for O_TRUNC and honours O_CREAT
+					   regardless of the O_RDONLY access mode, and a guest
+					   told the open succeeded would wrongly believe the file
+					   had been truncated or created. Mutation goes through
+					   the write branch and is_writable_path(). */
+					if (UNLIKELY(flags & (O_CREAT | O_TRUNC | O_APPEND))) {
+						regs.sysret() = -EACCES;
+						cpu.set_registers(regs);
+						SYSPRINT("OPENAT fd=%d mutating flags on a read-only open: %s\n",
+							vfd, path.c_str());
+						return;
 					}
 					real_path = path;
 					if (UNLIKELY(!cpu.machine().fds().is_readable_path(real_path))) {
@@ -3053,23 +3089,24 @@ void Machine::setup_linux_system_calls(bool unsafe_syscalls)
 
 			try {
 				path = cpu.machine().memcstring(vpath, PATH_MAX);
-				if (!path.empty()) {
-					if (UNLIKELY(!cpu.machine().fds().is_readable_path(path))) {
-						regs.sysret() = -EPERM;
-					}
-				}
-				// Translate from vfd when fd != AT_FDCWD
-				if (vfd != AT_FDCWD)
-					fd = cpu.machine().fds().translate(vfd);
-
-				struct statx vstat;
-				const int result =
-					statx(fd, path.c_str(), flags, mask, &vstat);
-				if (result == 0) {
-					cpu.machine().copy_to_guest(buffer, &vstat, sizeof(vstat));
-					regs.sysret() = 0;
+				// An empty path means AT_EMPTY_PATH on the fd itself, which
+				// the policy has nothing to say about.
+				if (UNLIKELY(!cpu.machine().fds().is_readable_path(path) && !path.empty())) {
+					regs.sysret() = -EPERM;
 				} else {
-					regs.sysret() = -errno;
+					// Translate from vfd when fd != AT_FDCWD
+					if (vfd != AT_FDCWD)
+						fd = cpu.machine().fds().translate(vfd);
+
+					struct statx vstat;
+					const int result =
+						statx(fd, path.c_str(), flags, mask, &vstat);
+					if (result == 0) {
+						cpu.machine().copy_to_guest(buffer, &vstat, sizeof(vstat));
+						regs.sysret() = 0;
+					} else {
+						regs.sysret() = -errno;
+					}
 				}
 			} catch (...) {
 				regs.sysret() = -1;

--- a/tests/unit/syscalls.cpp
+++ b/tests/unit/syscalls.cpp
@@ -529,3 +529,185 @@ int main() {
 	REQUIRE(machine.return_value() == 0);
 	REQUIRE(elapsed < 5.0);
 }
+
+#include <sys/stat.h>
+
+TEST_CASE("openat read-only branch must not truncate or create files", "[Syscalls]")
+{
+	/* The openat handler takes its "read-only" branch whenever O_WRONLY/O_RDWR
+	   are absent, but it preserved O_CREAT and O_TRUNC from the guest's flags
+	   and passed them straight to openat2. A guest could therefore truncate an
+	   existing file -- or create a brand-new one -- through a path that the
+	   embedder policy only ever approved for READING.
+
+	   Mutation must be denied outright rather than have the bits quietly
+	   dropped: a guest told the open succeeded would go on believing the file
+	   had been truncated or created. Creating and truncating are reached
+	   through the write branch, which consults is_writable_path(). */
+	const auto binary = build_and_load(R"M(
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+int main() {
+	/* Both paths are admitted by the READ-ONLY policy the host installs, but
+	   both opens carry mutating flags, so both must be refused. */
+	int fd = open("/truncate-me", O_RDONLY | O_TRUNC);
+	if (fd >= 0) { close(fd); return 1; }
+	if (errno != EACCES) return 2;
+
+	fd = open("/create-me", O_RDONLY | O_CREAT, 0644);
+	if (fd >= 0) { close(fd); return 3; }
+	if (errno != EACCES) return 4;
+
+	/* A plain read of the same path must still work. */
+	fd = open("/truncate-me", O_RDONLY);
+	if (fd < 0) return 5;
+	close(fd);
+	return 0;
+})M");
+
+	ScratchFile file;
+	const std::string created_path = file.path + ".created";
+	unlink(created_path.c_str());
+
+	tinykvm::Machine machine { binary, { .max_mem = MAX_MEMORY } };
+	/* READ-ONLY policy: there is deliberately no writable callback. */
+	machine.fds().set_open_readable_callback(
+		[&](std::string& path) {
+			if (path == "/truncate-me") { path = file.path;    return true; }
+			if (path == "/create-me")   { path = created_path; return true; }
+			return false;
+		});
+	machine.fds().set_current_working_directory("/tmp");
+	machine.setup_linux({"openat-readonly-flags"}, env);
+	machine.run(4.0f);
+
+	REQUIRE(machine.return_value() == 0);
+
+	struct stat st;
+	const bool target_statted = (stat(file.path.c_str(), &st) == 0);
+	const off_t target_size = target_statted ? st.st_size : -1;
+	const bool created_exists = (stat(created_path.c_str(), &st) == 0);
+	unlink(created_path.c_str()); /* clean up even when the bug is present */
+
+	/* The read-approved file must be untouched ... */
+	REQUIRE(target_statted);
+	REQUIRE(target_size == 4096);
+	/* ... and no new file may have appeared. */
+	REQUIRE(!created_exists);
+}
+
+TEST_CASE("fcntl(F_SETFL) must not mutate a read-only host fd", "[Syscalls]")
+{
+	/* F_SETFL changes the status flags of the underlying host fd, but it
+	   resolved the vfd with the plain translate() rather than
+	   translate_writable_vfd(), so a guest could set O_NONBLOCK on an fd
+	   opened through the read-only policy. Forks share the master's real_fd
+	   and reset_to() does not restore file status flags, so the change
+	   outlives the request that made it. */
+	const auto binary = build_and_load(R"M(
+#define _GNU_SOURCE
+#include <fcntl.h>
+#include <unistd.h>
+
+int main() {
+	int fd = open("/readable", O_RDONLY);
+	if (fd < 0) return 1;
+
+	/* The fd is read-only, so this must be refused ... */
+	if (fcntl(fd, F_SETFL, O_NONBLOCK) == 0) return 2;
+
+	/* ... and the flag must not have stuck on the host fd. F_GETFL reports
+	   the host fd's O_NONBLOCK bit back to us. */
+	const int flags = fcntl(fd, F_GETFL);
+	if (flags < 0) return 3;
+	if (flags & O_NONBLOCK) return 4;
+
+	close(fd);
+	return 0;
+})M");
+
+	ScratchFile file;
+	tinykvm::Machine machine { binary, { .max_mem = MAX_MEMORY } };
+	/* READ-ONLY policy: there is deliberately no writable callback. */
+	allow_scratch_file(machine, file);
+	machine.fds().set_current_working_directory("/tmp");
+	machine.setup_linux({"fcntl-setfl-readonly"}, env);
+	machine.run(4.0f);
+
+	REQUIRE(machine.return_value() == 0);
+}
+
+TEST_CASE("statx on a policy-denied path must not return host stat data", "[Syscalls]")
+{
+	/* The statx handler checked is_readable_path() and stored -EPERM when the
+	   embedder policy denied the path -- but then fell through to a host
+	   statx() on the original guest path anyway, overwriting the error and
+	   copying real host stat data into the guest. Its sibling newfstatat
+	   correctly stops after the denial. */
+	const auto binary = build_and_load(R"M(
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+
+int main() {
+	struct statx stx;
+	memset(&stx, 0xAA, sizeof(stx));
+
+	/* The host policy denies EVERY path, so this must fail. */
+	errno = 0;
+	long r = syscall(SYS_statx, AT_FDCWD, "/etc/passwd", 0, STATX_BASIC_STATS, &stx);
+	if (r == 0) return 1; /* host stat data was leaked to the guest */
+	if (errno != EPERM && errno != EACCES) return 2;
+	return 0;
+})M");
+
+	tinykvm::Machine machine { binary, { .max_mem = MAX_MEMORY } };
+	/* Deny everything: a correct statx can never succeed on any path. */
+	machine.fds().set_open_readable_callback(
+		[](std::string&) { return false; });
+	machine.fds().set_current_working_directory("/tmp");
+	machine.setup_linux({"statx-denied"}, env);
+	machine.run(4.0f);
+
+	REQUIRE(machine.return_value() == 0);
+}
+
+TEST_CASE("unlinkat reads its path and flags from the correct registers", "[Syscalls]")
+{
+	/* The handler swapped its argument registers: it read `flags` from
+	   sysarg(1) (the path pointer) and the path pointer from sysarg(2) (the
+	   flags). A plain unlinkat(AT_FDCWD, path, 0) therefore called the host
+	   unlinkat() with garbage flags (EINVAL) and never removed anything. */
+	const auto binary = build_and_load(R"M(
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/syscall.h>
+
+int main() {
+	/* Perfectly legal unlinkat of a policy-approved file. */
+	errno = 0;
+	long r = syscall(SYS_unlinkat, AT_FDCWD, "/scratch", 0);
+	if (r != 0) return 1;
+	return 0;
+})M");
+
+	ScratchFile file;
+	tinykvm::Machine machine { binary, { .max_mem = MAX_MEMORY } };
+	allow_scratch_file(machine, file);
+	machine.setup_linux({"unlinkat-args"}, env);
+	machine.run(4.0f);
+
+	REQUIRE(machine.return_value() == 0);
+	/* The scratch file must really be gone (the destructor tolerates this). */
+	REQUIRE(access(file.path.c_str(), F_OK) != 0);
+}
+


### PR DESCRIPTION
Fixes #94, #95, #96 and #97 — the four policy gaps from the audit. Each is small and independent, but they are all in the same handler file and share one theme (a path or fd check that does not actually gate what follows), so they are batched.

One judgement call worth review, on #94. The obvious fix is to clear `O_CREAT|O_TRUNC|O_APPEND` before building `open_how`, but then `open(path, O_RDONLY|O_CREAT)` on a missing file "succeeds" without creating it, and `O_TRUNC` "succeeds" without truncating — the guest is told something that is not true. This instead denies the open with `-EACCES`. Mutation is what the write branch and `is_writable_path()` are for. Happy to switch to stripping if you would rather keep the call succeeding.

`setsockopt` grows a `try`/`catch` as part of the #97 fix: `translate_writable_vfd()` throws for a non-writable fd, and that handler had no catch, so switching to it without one would have turned a policy check into a foreign exception escaping `system_call()` — the bug in #101/#102.

Tests: the `openat`, `statx` and `unlinkat` cases already written for the audit, plus a new `fcntl` case (#97 had none) that checks both the return value and, via `F_GETFL`, that `O_NONBLOCK` did not stick on the host fd. Verified it goes red without the fix.

`tests/unit/syscalls.cpp` is 16/16 green on this branch. The pre-existing `tegridy` failures and the `reset` "crash recovery" failure are untouched and also fail on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)