### PR TITLE
seccomp: allow fsync, fchmod, ftruncate and epoll_pwait2 at runtime

### DIFF
--- a/lib/tinykvm/linux/seccomp.cpp
+++ b/lib/tinykvm/linux/seccomp.cpp
@@ -65,6 +65,9 @@ static std::vector<SeccompRule> runtime_rules()
 		R{SYS_lseek}, R{SYS_close}, R{SYS_fstat}, R{SYS_newfstatat},
 		R{SYS_statx}, R{SYS_fcntl}, R{SYS_dup}, R{SYS_dup3},
 		R{SYS_getdents64},
+		/* Mutating operations on already-translated fds. The fd was
+		 * approved when it was opened; these do not widen that. */
+		R{SYS_fsync}, R{SYS_fchmod}, R{SYS_ftruncate},
 		/* Path-based, mediated by is_readable_path/is_writable_path.
 		 * BPF cannot see the path; depth belongs to the emulation layer. */
 		R{SYS_openat}, R{SYS_readlinkat}, R{SYS_faccessat},
@@ -90,6 +93,11 @@ static std::vector<SeccompRule> runtime_rules()
 		/* --- Event loops --- */
 		R{SYS_epoll_create1}, R{SYS_epoll_ctl}, R{SYS_epoll_pwait},
 		R{SYS_ppoll},
+#ifdef SYS_epoll_pwait2
+		/* preempt_epoll_wait() is on by default, and that path issues
+		 * epoll_pwait2 rather than the epoll_wait the guest asked for. */
+		R{SYS_epoll_pwait2},
+#endif
 #ifdef SYS_epoll_wait
 		R{SYS_epoll_wait},
 #endif
@@ -165,7 +173,7 @@ static std::vector<SeccompRule> init_rules()
 		R{SYS_statfs}, R{SYS_fstatfs}, R{SYS_getcwd}, R{SYS_chdir},
 		R{SYS_fchdir}, R{SYS_mkdirat}, R{SYS_unlinkat}, R{SYS_renameat},
 		R{SYS_renameat2}, R{SYS_symlinkat}, R{SYS_linkat},
-		R{SYS_ftruncate}, R{SYS_fallocate}, R{SYS_copy_file_range},
+		R{SYS_fallocate}, R{SYS_copy_file_range},
 		R{SYS_sendfile}, R{SYS_flock}, R{SYS_umask}, R{SYS_memfd_create},
 		R{SYS_msync}, R{SYS_mincore}, R{SYS_mlock}, R{SYS_munlock},
 		/* unsafe_syscalls mode (setup_linux_system_calls) */

--- a/tests/unit/seccomp.cpp
+++ b/tests/unit/seccomp.cpp
@@ -156,3 +156,107 @@ TEST_CASE("Extra rules extend the allowlist", "[Seccomp]")
 	REQUIRE(WIFEXITED(status));
 	REQUIRE(WEXITSTATUS(status) == 0);
 }
+
+/* --------------------------------------------------------------------- */
+/* Regression tests for runtime-allowlist omissions. The syscall          */
+/* emulation layer (linux/system_calls.cpp) legitimately performs these   */
+/* host syscalls on behalf of an ordinary guest, but the Runtime filter   */
+/* does not allow them, so the VMM process is killed by SIGSYS. Each test */
+/* asserts the correct behavior (guest completes under the filter) and    */
+/* currently FAILS: the child dies with SIGSYS.                           */
+/* --------------------------------------------------------------------- */
+
+TEST_CASE("Runtime filter allows guest epoll_wait", "[Seccomp]")
+{
+	/* The emulated epoll_wait handler waits on the host with
+	   SYS_epoll_pwait2 (system_calls.cpp), which is missing from the
+	   runtime allowlist (only epoll_wait/epoll_pwait are listed). */
+	const auto binary = build_and_load(R"M(
+#include <sys/epoll.h>
+int main() {
+	int e = epoll_create1(0);
+	if (e < 0) return 10;
+	struct epoll_event ev[4];
+	int r = epoll_wait(e, ev, 4, 0);
+	return (r >= 0) ? 42 : 11;
+})M");
+
+	const int status = run_in_child([&] {
+		tinykvm::install_seccomp_filter(tinykvm::SeccompPhase::Runtime);
+		tinykvm::Machine machine { binary, { .max_mem = MAX_MEMORY } };
+		machine.setup_linux({"seccomp"}, env);
+		machine.run(4.0f);
+		_exit(machine.return_value() == 42 ? 0 : 1);
+	});
+	REQUIRE(WIFEXITED(status));
+	REQUIRE(WEXITSTATUS(status) == 0);
+}
+
+TEST_CASE("Runtime filter allows guest fsync", "[Seccomp]")
+{
+	/* The emulated fsync handler passes the call through to the host fd,
+	   but SYS_fsync is missing from the runtime allowlist. */
+	const auto binary = build_and_load(R"M(
+#include <unistd.h>
+int main() {
+	fsync(1); /* result does not matter; the host call must be allowed */
+	return 43;
+})M");
+
+	const int status = run_in_child([&] {
+		tinykvm::install_seccomp_filter(tinykvm::SeccompPhase::Runtime);
+		tinykvm::Machine machine { binary, { .max_mem = MAX_MEMORY } };
+		machine.setup_linux({"seccomp"}, env);
+		machine.run(4.0f);
+		_exit(machine.return_value() == 43 ? 0 : 1);
+	});
+	REQUIRE(WIFEXITED(status));
+	REQUIRE(WEXITSTATUS(status) == 0);
+}
+
+TEST_CASE("Runtime filter allows guest fchmod", "[Seccomp]")
+{
+	/* The emulated fchmod handler passes the call through to the host fd,
+	   but SYS_fchmod is missing from the runtime allowlist. */
+	const auto binary = build_and_load(R"M(
+#define _GNU_SOURCE
+#include <sys/stat.h>
+int main() {
+	fchmod(1, 0); /* result does not matter; the host call must be allowed */
+	return 44;
+})M");
+
+	const int status = run_in_child([&] {
+		tinykvm::install_seccomp_filter(tinykvm::SeccompPhase::Runtime);
+		tinykvm::Machine machine { binary, { .max_mem = MAX_MEMORY } };
+		machine.setup_linux({"seccomp"}, env);
+		machine.run(4.0f);
+		_exit(machine.return_value() == 44 ? 0 : 1);
+	});
+	REQUIRE(WIFEXITED(status));
+	REQUIRE(WEXITSTATUS(status) == 0);
+}
+
+TEST_CASE("Runtime filter allows guest ftruncate", "[Seccomp]")
+{
+	/* The emulated ftruncate handler passes the call through to the host
+	   fd, but SYS_ftruncate is only in the init-phase allowlist, not the
+	   runtime one. */
+	const auto binary = build_and_load(R"M(
+#define _GNU_SOURCE
+#include <unistd.h>
+int main() {
+	ftruncate(1, 0); /* result does not matter; the host call must be allowed */
+	return 45;
+})M");
+
+	const int status = run_in_child([&] {
+		tinykvm::install_seccomp_filter(tinykvm::SeccompPhase::Runtime);
+		tinykvm::Machine machine { binary, { .max_mem = MAX_MEMORY } };
+		machine.setup_linux({"seccomp"}, env);
+		machine.run(4.0f);
+		_exit(machine.return_value() == 45 ? 0 : 1);
+	});
+	REQUIRE(WIFEXITED(status));
+	REQUIRE(WEXITSTATUS(status) == 0);
+}


### PR DESCRIPTION
The Runtime filter was missing four syscalls the default emulation layer can issue for an ordinary guest, so each one killed the VMM process with SIGSYS rather than being served:

| syscall | reached from |
|---|---|
| `fsync` | handler at `system_calls.cpp:1915` |
| `fchmod` | handler at `:2051` |
| `ftruncate` | handler at `:3228` |
| `epoll_pwait2` | the `epoll_wait` handler's `preempt_epoll_wait()` path, which is **on by default** |

All three handlers are installed before the `unsafe_syscalls` boundary, so they are in the default safe set.

None of these widens the sandbox: every one operates on an fd the emulation layer already translated, and that fd was approved when it was opened. `ftruncate` moves out of `init_rules()`, which no longer needs to name it now that `runtime_rules()` carries it.

I left `fdatasync` out even though it pairs naturally with `fsync` — there is no `SYS_fdatasync` handler, so allowing it would widen the filter beyond what the emulation layer can actually issue.

Adds four tests, one per syscall, each running the guest under the Runtime filter in a forked child so the SIGSYS is contained. `tests/unit/seccomp.cpp` goes from 7/11 to 11/11.

This is drift the existing tests structurally could not catch: they only exercised `printf`/`write` under the Runtime filter. A generic guard — a smoke guest walking the whole safe syscall surface, or a CI check diffing `strace -f -c` against `runtime_rules()` — would be worth adding separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)