### PR TITLE
linux: stop the guest sleeping the host, and close the cwd fd

### DIFF
--- a/lib/tinykvm/linux/fds.cpp
+++ b/lib/tinykvm/linux/fds.cpp
@@ -51,6 +51,12 @@ namespace tinykvm
 				close(entry.real_fd);
 			}
 		}
+		// Not in m_fds, and never shared with the master: forks open their
+		// own only when the embedder sets a working directory.
+		if (m_current_working_directory_fd >= 0) {
+			close(m_current_working_directory_fd);
+			m_current_working_directory_fd = AT_FDCWD;
+		}
 	}
 
 	void FileDescriptors::reset_to(const FileDescriptors& other)
@@ -465,6 +471,12 @@ namespace tinykvm
 	void FileDescriptors::set_current_working_directory(const std::string& path) noexcept
 	{
 		m_current_working_directory = path;
+		// This fd is not in m_fds, so reset_to() does not reach it. Close the
+		// previous one here or re-applying a policy leaks one fd per call.
+		if (m_current_working_directory_fd >= 0) {
+			close(m_current_working_directory_fd);
+			m_current_working_directory_fd = AT_FDCWD;
+		}
 		// Set the current working directory fd by opening the path
 		int fd = open(path.c_str(), O_RDONLY | O_DIRECTORY);
 		m_current_working_directory_fd = fd;

--- a/lib/tinykvm/linux/system_calls.cpp
+++ b/lib/tinykvm/linux/system_calls.cpp
@@ -2368,24 +2368,56 @@ void Machine::setup_linux_system_calls(bool unsafe_syscalls)
 		});
 	Machine::install_syscall_handler(
 		SYS_clock_nanosleep, [](vCPU& cpu) { // clock_nanosleep
+			/* The request is guest-controlled, so sleeping on it would let the
+			   guest park the VMM thread for as long as it likes. SYS_nanosleep
+			   is a deliberate no-op for that reason, and modern glibc routes
+			   nanosleep() here -- validate as Linux does, then do not sleep. */
 			auto& regs = cpu.registers();
-			const uint64_t g_buf = regs.sysarg(2);
-			const uint64_t g_rem = regs.sysarg(3);
-			struct timespec ts;
-			struct timespec ts_rem {};
-			cpu.machine().copy_from_guest(&ts, g_buf, sizeof(ts));
-			const int result =
-				clock_nanosleep(CLOCK_MONOTONIC, regs.sysarg(1), &ts, &ts_rem);
-			if (result < 0) {
-				regs.sysret() = -errno;
-			} else {
-				if (g_rem != 0x0)
-					cpu.machine().copy_to_guest(g_rem, &ts_rem, sizeof(ts_rem));
-				regs.sysret() = 0;
+			const uint64_t g_clockid = regs.sysarg(0);
+			const uint64_t g_flags   = regs.sysarg(1);
+			const uint64_t g_req     = regs.sysarg(2);
+
+			bool valid_clock = false;
+			switch (g_clockid) {
+			case CLOCK_REALTIME:
+			case CLOCK_MONOTONIC:
+			case CLOCK_BOOTTIME:
+			case CLOCK_PROCESS_CPUTIME_ID:
+			case CLOCK_THREAD_CPUTIME_ID:
+				valid_clock = true;
+				break;
+			default:
+				valid_clock = false;
 			}
+			/* TIMER_ABSTIME is the only flag Linux accepts here. */
+			if (UNLIKELY(!valid_clock || (g_flags & ~uint64_t(TIMER_ABSTIME)) != 0)) {
+				regs.sysret() = -EINVAL;
+				cpu.set_registers(regs);
+				SYSPRINT("clock_nanosleep(clk=%llu, flags=0x%llX, bad args) = %lld\n",
+						 (unsigned long long)g_clockid, (unsigned long long)g_flags,
+						 regs.sysret());
+				return;
+			}
+
+			struct timespec ts {};
+			cpu.machine().copy_from_guest(&ts, g_req, sizeof(ts));
+			if (UNLIKELY(ts.tv_sec < 0 || ts.tv_nsec < 0 || ts.tv_nsec >= 1000000000L)) {
+				regs.sysret() = -EINVAL;
+				cpu.set_registers(regs);
+				SYSPRINT("clock_nanosleep(clk=%llu, flags=0x%llX, bad timespec) = %lld\n",
+						 (unsigned long long)g_clockid, (unsigned long long)g_flags,
+						 regs.sysret());
+				return;
+			}
+
+			/* Report the sleep as completed in full. Nothing is written to the
+			   remain buffer: that is only for an interrupted sleep. */
+			regs.sysret() = 0;
 			cpu.set_registers(regs);
-			SYSPRINT("clock_nanosleep(clk=%lld, flags=%lld, req=0x%llX, rem=%lld) = %lld\n",
-					 regs.sysarg(0), regs.sysarg(1), regs.sysarg(2), regs.sysarg(3), regs.sysret());
+			SYSPRINT("clock_nanosleep(clk=%llu, flags=0x%llX, req=0x%llX, rem=0x%llX) = %lld\n",
+					 (unsigned long long)g_clockid, (unsigned long long)g_flags,
+					 (unsigned long long)g_req, (unsigned long long)regs.sysarg(3),
+					 regs.sysret());
 		});
 	Machine::install_syscall_handler(
 		SYS_exit_group, [](vCPU& cpu)

--- a/tests/unit/syscalls.cpp
+++ b/tests/unit/syscalls.cpp
@@ -529,3 +529,62 @@ int main() {
 	REQUIRE(machine.return_value() == 0);
 	REQUIRE(elapsed < 5.0);
 }
+
+TEST_CASE("clock_nanosleep cannot sleep the host", "[Syscalls]")
+{
+	/* The request comes straight from the guest, so passing it to the host
+	   clock_nanosleep() let a guest park the VMM thread for as long as it
+	   liked -- found by the syscall fuzzer as a hang, not a crash. SYS_nanosleep
+	   was already a no-op for exactly this reason, but modern glibc routes
+	   nanosleep() through clock_nanosleep, so that no-op covered almost nothing.
+
+	   Note that a regression here does not fail fast: the host thread is stuck
+	   inside the syscall handler, where the execution timeout does not reach it,
+	   so the test hangs until CTest's own timeout fires. */
+	const auto binary = build_and_load(R"M(
+#define _GNU_SOURCE
+#include <time.h>
+#include <errno.h>
+
+int main() {
+	struct timespec req;
+
+	/* A very long relative sleep must return without blocking. */
+	req.tv_sec = 1000000; req.tv_nsec = 0;
+	const int r1 = clock_nanosleep(CLOCK_MONOTONIC, 0, &req, 0);
+
+	/* ... and so must an absolute deadline far in the future. */
+	req.tv_sec = 1L << 40; req.tv_nsec = 0;
+	const int r2 = clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &req, 0);
+
+	/* Out-of-range tv_nsec is rejected the way Linux rejects it. glibc
+	   returns the error positively rather than through errno. */
+	req.tv_sec = 0; req.tv_nsec = 2000000000L;
+	const int r3 = clock_nanosleep(CLOCK_MONOTONIC, 0, &req, 0);
+
+	/* Negative tv_sec likewise. */
+	req.tv_sec = -1; req.tv_nsec = 0;
+	const int r4 = clock_nanosleep(CLOCK_MONOTONIC, 0, &req, 0);
+
+	/* TIMER_ABSTIME is the only accepted flag. */
+	req.tv_sec = 0; req.tv_nsec = 0;
+	const int r5 = clock_nanosleep(CLOCK_MONOTONIC, 0x4, &req, 0);
+
+	return (r1 == 0)
+		| ((r2 == 0)      << 1)
+		| ((r3 == EINVAL) << 2)
+		| ((r4 == EINVAL) << 3)
+		| ((r5 == EINVAL) << 4);
+})M");
+
+	tinykvm::Machine machine { binary, { .max_mem = MAX_MEMORY } };
+	machine.setup_linux({"clock-nanosleep"}, env);
+
+	const auto t0 = std::chrono::steady_clock::now();
+	machine.run(30.0f);
+	const auto elapsed = std::chrono::duration<double>(
+		std::chrono::steady_clock::now() - t0).count();
+
+	REQUIRE(machine.return_value() == 0x1F);
+	REQUIRE(elapsed < 5.0);
+}


### PR DESCRIPTION
Two bugs found by `fuzz/syscall_fuzz.cpp` on a 10h ARM64 campaign. Both are in shared code, not ARM64-specific.

**`clock_nanosleep` let the guest park the VMM thread.** The guest's `timespec` and flags went straight to the host `clock_nanosleep()`, so a large `tv_sec` — or `TIMER_ABSTIME` with a far-future deadline — blocked indefinitely. `SYS_nanosleep` was already a no-op to prevent exactly this, but modern glibc routes `nanosleep()` through `clock_nanosleep`, so that no-op covered almost nothing. Now validates like Linux (EINVAL on bad clockid, unknown flags, out-of-range `tv_nsec`, negative `tv_sec`) and returns without sleeping. The old error branch was dead code: `clock_nanosleep(3)` returns errno positively and never sets `errno`, so failures were reported to the guest as success.

**`set_current_working_directory()` leaked a directory fd per call.** The fd is kept outside `m_fds`, so neither `reset_to()` nor `~FileDescriptors()` reached it, and re-setting dropped the previous one. An embedder re-applying its policy per warm fork leaks one fd per request. Each leaked fd also pins ~24 KiB of unreclaimable kernel slab on a 16 KiB-page host.

The fd leak is what wrecked the fuzzing campaign: workers reached ~100k fds in minutes, `SUnreclaim` hit 4.4 GB and `MemAvailable` fell to 83 MB, after which children died during VM setup and were tallied as 93 artifact-less "crashes". Killing the workers returned 4.2 GB instantly.

## Verification

- The three artifacts that used to hang for 60+ seconds now replay in <1 ms.
- Worker fd count flat at 13 over 260k executions; `SUnreclaim` back to ~235 MB.
- A 5h43m re-run after both fixes: 183M executions, **0 crashes, 0 timeouts, 0 OOMs** (same fuzzer and corpus that produced 93 crashes before).
- All 6 ARM64 unit suites pass.

Adds a regression test to `tests/unit/syscalls.cpp`. Note that file is only registered for AMD64 in `tests/unit/CMakeLists.txt`, so it runs in AMD64 CI; on ARM64 I verified the fix with a standalone guest instead.