### PR TITLE
arm64: snapshot the CoW sysregs at prepare, not from the master's fd

### DIFF
--- a/lib/tinykvm/arm64/vcpu.cpp
+++ b/lib/tinykvm/arm64/vcpu.cpp
@@ -3,6 +3,7 @@
 #include "memory_layout.hpp"
 #include "paging.hpp"
 #include "../page_streaming.hpp"
+#include <array>
 #include <cerrno>
 #include <cstddef>
 #include <cstring>
@@ -562,11 +563,41 @@ void vCPU::set_vcpu_table_at(unsigned index, int value)
 	*((int*)&page[offset]) = value;
 }
 
+/* The EL1 system registers every fork inherits verbatim from its master. The
+   order is the snapshot's ABI: prepared_sysregs() is indexed by it. */
+static constexpr size_t COW_SYSREG_COUNT = 5;
+static std::array<uint64_t, COW_SYSREG_COUNT> cow_sysreg_ids()
+{
+	return {
+		sys_reg_id(3, 0, 10, 2, 0), // MAIR_EL1
+		sys_reg_id(3, 0, 2, 0, 2),  // TCR_EL1
+		sys_reg_id(3, 0, 1, 0, 0),  // SCTLR_EL1
+		sys_reg_id(3, 0, 1, 0, 2),  // CPACR_EL1
+		sys_reg_id(3, 0, 12, 0, 0), // VBAR_EL1
+	};
+}
+
 void Machine::prepare_copy_on_write(size_t max_work_mem,
 	uint64_t shared_memory_boundary, bool split_accessed_hugepages)
 {
 	this->m_prepped = true;
 	this->m_prepared_fpu_regs = this->fpu_registers();
+	/* Snapshot the CoW system registers and warm the register cache while this
+	   master's vCPU fd is still ours to ioctl. A fork built in a *different*
+	   process (process-per-VM: the worker inherits the master over fork() and
+	   creates its own VM) cannot issue vCPU ioctls against the master's fd --
+	   KVM binds a VM to the creating mm and answers -EIO otherwise -- so both
+	   setup_cow_mode() and the fork constructor's other.registers() read from
+	   userspace instead. Same contract, and same "the master is frozen after
+	   this point" justification, as m_prepared_fpu_regs. */
+	{
+		const auto ids = cow_sysreg_ids();
+		for (size_t i = 0; i < COW_SYSREG_COUNT; i++) {
+			get_one_reg(this->vcpu.fd, ids[i], this->m_prepared_sysregs[i]);
+		}
+		/* const overload: caching a read must not mark the master dirty. */
+		(void) static_cast<const vCPU&>(this->vcpu).registers();
+	}
 	if (shared_memory_boundary == 0)
 		shared_memory_boundary = UINT64_MAX;
 
@@ -591,17 +622,14 @@ void Machine::setup_cow_mode(const Machine* other)
 	memory.page_tables = clone_arm64_page_table(memory, other->memory,
 		other->memory.page_tables, 1);
 
-	const uint64_t sysregs[] {
-		sys_reg_id(3, 0, 10, 2, 0), // MAIR_EL1
-		sys_reg_id(3, 0, 2, 0, 2),  // TCR_EL1
-		sys_reg_id(3, 0, 1, 0, 0),  // SCTLR_EL1
-		sys_reg_id(3, 0, 1, 0, 2),  // CPACR_EL1
-		sys_reg_id(3, 0, 12, 0, 0), // VBAR_EL1
-	};
-	for (uint64_t reg_id : sysregs) {
-		__u64 value = 0;
-		get_one_reg(other->vcpu.fd, reg_id, value);
-		set_one_reg(this->vcpu.fd, reg_id, value);
+	/* Take the master's EL1 sysregs from its prepare-time snapshot, never from
+	   a live KVM_GET_ONE_REG on other->vcpu.fd: a worker process that inherited
+	   the master over fork() owns neither that fd's VM nor its mm, and the read
+	   fails with -EIO. See Machine::prepared_sysregs(). */
+	const auto ids = cow_sysreg_ids();
+	const auto& values = other->prepared_sysregs();
+	for (size_t i = 0; i < COW_SYSREG_COUNT; i++) {
+		set_one_reg(this->vcpu.fd, ids[i], values[i]);
 	}
 	set_one_reg(this->vcpu.fd, sys_reg_id(3, 0, 2, 0, 0), memory.page_tables);
 

--- a/lib/tinykvm/machine.hpp
+++ b/lib/tinykvm/machine.hpp
@@ -155,6 +155,21 @@ struct Machine
 		assert(m_prepped && "prepared_fpu_registers() requires prepare_copy_on_write()");
 		return m_prepared_fpu_regs;
 	}
+#if defined(TINYKVM_ARCH_ARM64)
+	/* The EL1 system registers a fork inherits from its master (MAIR_EL1,
+	   TCR_EL1, SCTLR_EL1, CPACR_EL1, VBAR_EL1), snapshotted by
+	   prepare_copy_on_write() for exactly the reason above: setup_cow_mode()
+	   used to read them back with KVM_GET_ONE_REG on the *master's* vCPU fd,
+	   which is -EIO from a process that merely inherited that fd over fork().
+	   AMD64 has no equivalent read (its analogue, get_special_registers(), is
+	   served from the synced-regs page), so this is the ARM64 half of the same
+	   contract. Frozen master => the snapshot equals a live read. */
+	using PreparedSysregs = std::array<__u64, 5>;
+	const PreparedSysregs& prepared_sysregs() const noexcept {
+		assert(m_prepped && "prepared_sysregs() requires prepare_copy_on_write()");
+		return m_prepared_sysregs;
+	}
+#endif
 	const kvm_sregs& get_special_registers() const;
 	void set_special_registers(const kvm_sregs&);
 	std::pair<__u64, __u64> get_fsgs() const;
@@ -475,6 +490,10 @@ private:
 	void* m_userdata = nullptr;
 	/* See prepared_fpu_registers(). */
 	tinykvm_fpuregs m_prepared_fpu_regs {};
+#if defined(TINYKVM_ARCH_ARM64)
+	/* See prepared_sysregs(). */
+	PreparedSysregs m_prepared_sysregs {};
+#endif
 
 	std::string_view m_binary;
 


### PR DESCRIPTION
Building a fork in a process that merely inherited the master over fork() --
the process-per-VM topology in the parent repo -- died on ARM64 with
KVM_GET_ONE_REG -EIO before the worker could serve a byte. KVM binds a VM to
the creating process's mm and answers vCPU ioctls from any other mm with -EIO,
which is exactly why the AMD64 path already reads no master fd: its general
regs and sregs come from the synced-regs page and its FPU state from the
prepare-time snapshot (prepared_fpu_registers).

ARM64 had no equivalent for two reads that the fork constructor still made
against other->vcpu.fd:

  - setup_cow_mode() read MAIR_EL1, TCR_EL1, SCTLR_EL1, CPACR_EL1 and
    VBAR_EL1 back off the master to copy them into the fork. This is the
    read that failed; it has no AMD64 twin because get_special_registers()
    there is served from the synced-regs page.
  - the constructor's other.registers() would issue 34 core-register reads
    on the master whenever its register cache happened to be cold.

Both now come from userspace. prepare_copy_on_write() snapshots the five
sysregs into m_prepared_sysregs and warms the master's register cache while
the master's own fd is still ioctl-able, on the same justification the FPU
snapshot rests on: the master is frozen after prepare and never run again, so
the snapshot stays equal to a live read. setup_cow_mode() then only writes,
never reads, and the reg-id list lives in one function (cow_sysreg_ids) so the
snapshot's index order cannot drift from its consumer.

AMD64 is untouched: the new member and accessor are ARM64-only.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

Found and verified from fast-agent issue [varnish/fast-agent#66](https://github.com/varnish/fast-agent/issues/66): process-per-VM (the default topology) could not create a single fork on aarch64. With this commit the full jailed topology serves turns on a Fedora Asahi (16K page) host — 2400 turns, 0 errors — and `ctest --preset kvm` is 15/15 there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)