### PR TITLE
fix: release the vCPU fd, POSIX timer and VM fd when a Machine constructor throws

### DIFF
--- a/lib/tinykvm/arm64/vcpu.cpp
+++ b/lib/tinykvm/arm64/vcpu.cpp
@@ -86,6 +86,8 @@ void vCPU::init(int kvm_vcpu_id, int guest_cpu_index, Machine& machine, const Ma
 	this->guest_cpu_index = guest_cpu_index;
 	this->last_fault_address = 0;
 	this->m_machine = &machine;
+	/* Not a seat: everything acquired below is this vCPU's to release. */
+	this->m_seat_borrowed = false;
 
 	if (this->fd < 0) {
 		this->fd = ioctl(machine.fd, KVM_CREATE_VCPU, this->kvm_vcpu_id);
@@ -111,11 +113,15 @@ void vCPU::init(int kvm_vcpu_id, int guest_cpu_index, Machine& machine, const Ma
 	   pins for pooled seats, but honoured here too so a lazy master/plain fork
 	   behaves the same. */
 	if (this->kvm_run == nullptr && !options.lazy_vcpu_mmap) {
-		kvm_run = (struct kvm_run*) ::mmap(NULL, vcpu_mmap_size,
+		auto* mapping = (struct kvm_run*) ::mmap(NULL, vcpu_mmap_size,
 			PROT_READ | PROT_WRITE, MAP_SHARED, this->fd, 0);
-		if (UNLIKELY(kvm_run == MAP_FAILED)) {
+		/* Assigned only on success: MAP_FAILED is not a null pointer, and
+		   ~vCPU/deinit() would take a non-null kvm_run as a live mapping and
+		   munmap((void*)-1). */
+		if (UNLIKELY(mapping == MAP_FAILED)) {
 			Machine::machine_exception("Failed to create KVM run-time mapped memory");
 		}
+		this->kvm_run = mapping;
 	}
 }
 
@@ -126,6 +132,10 @@ void vCPU::init_from_seat(VmGroupSeat& seat, Machine& machine,
 	this->guest_cpu_index = 0;
 	this->last_fault_address = 0;
 	this->m_machine = &machine;
+	/* Armed before anything is taken: from here on fd, kvm_run and the timer
+	   are the seat's, and ~vCPU must not close, unmap or delete any of them
+	   however this function exits. */
+	this->m_seat_borrowed = true;
 
 	/* The seat's vCPU is created when the group materializes the seat and is
 	   adopted, never created, here -- see the AMD64 twin (vcpu.cpp) for why
@@ -161,11 +171,14 @@ void vCPU::init_from_seat(VmGroupSeat& seat, Machine& machine,
 	if (seat.kvm_run != nullptr) {
 		this->kvm_run = (struct kvm_run *)seat.kvm_run;
 	} else if (!options.lazy_vcpu_mmap) {
-		this->kvm_run = (struct kvm_run*) ::mmap(NULL, vcpu_mmap_size,
+		auto* mapping = (struct kvm_run*) ::mmap(NULL, vcpu_mmap_size,
 			PROT_READ | PROT_WRITE, MAP_SHARED, this->fd, 0);
-		if (UNLIKELY(this->kvm_run == MAP_FAILED)) {
+		/* Assigned only on success, so a failure does not leave MAP_FAILED
+		   behind for the seat (and its next tenant) to adopt as a mapping. */
+		if (UNLIKELY(mapping == MAP_FAILED)) {
 			Machine::machine_exception("Failed to map VM group seat kvm_run");
 		}
+		this->kvm_run = mapping;
 		seat.kvm_run = this->kvm_run;
 	}
 
@@ -212,17 +225,20 @@ void vCPU::detach_to_seat(VmGroupSeat& seat) noexcept
 	this->timer_tid = 0;
 	this->m_regs_cached = false;
 	this->m_regs_dirty = false;
+	this->m_seat_borrowed = false;
 }
 
 void vCPU::ensure_kvm_run()
 {
 	if (LIKELY(this->kvm_run != nullptr))
 		return;
-	this->kvm_run = (struct kvm_run*) ::mmap(NULL, vcpu_mmap_size,
+	auto* mapping = (struct kvm_run*) ::mmap(NULL, vcpu_mmap_size,
 		PROT_READ | PROT_WRITE, MAP_SHARED, this->fd, 0);
-	if (UNLIKELY(this->kvm_run == MAP_FAILED)) {
+	/* Assigned only on success: see init(). */
+	if (UNLIKELY(mapping == MAP_FAILED)) {
 		Machine::machine_exception("Failed to lazily map kvm_run");
 	}
+	this->kvm_run = mapping;
 	/* A pooled member's mapping belongs to its seat so the next tenant adopts
 	   it rather than re-mapping: one host VMA per seat, never per tenant. Same
 	   write-back the AMD64 lazily_map_kvm_run() does. */
@@ -246,9 +262,11 @@ void vCPU::smp_init(int, Machine&)
 	throw MachineException("SMP is not implemented on ARM64");
 }
 
+/* Idempotent, and clears every field it releases: ~vCPU calls it a second time
+   for the objects ~Machine never reaches. */
 void vCPU::deinit()
 {
-	if (this->fd > 0) {
+	if (this->fd >= 0) {
 		close(this->fd);
 		this->fd = -1;
 	}
@@ -259,6 +277,17 @@ void vCPU::deinit()
 	if (this->timer_id != nullptr) {
 		timer_delete((timer_t)this->timer_id);
 		this->timer_id = nullptr;
+		this->timer_tid = 0;
+	}
+}
+
+vCPU::~vCPU()
+{
+	/* See the declaration: this is the release path for a Machine constructor
+	   that threw after vCPU bring-up, where ~Machine (and therefore deinit())
+	   never runs. A seat's fd/kvm_run/timer are not ours to release. */
+	if (!this->m_seat_borrowed) {
+		this->deinit();
 	}
 }
 

--- a/lib/tinykvm/machine.cpp
+++ b/lib/tinykvm/machine.cpp
@@ -45,9 +45,15 @@ Machine::Machine(std::string_view binary, const MachineOptions& options)
 	if (options.mmap_backed_files && !options.snapshot_file.empty()) {
 		throw MachineException("Cannot have VM snapshot with mmap-backed files at the same time");
 	}
+	/* Everything from the VM fd on is leaked if a later step throws (the ELF
+	   loader is the likely one here) -- ~Machine does not run for a
+	   constructor that threw. See Machine::CtorGuard. */
+	CtorGuard guard;
 	/* vm_group only engages for forks (like lazy_vcpu_mmap): a master owns
 	   its own VM and simply passes the flag on through its fork options. */
 	this->fd = create_kvm_vm();
+	guard.machine = this;
+	guard.vm_fd = true;
 
 #if defined(TINYKVM_ARCH_ARM64)
 	if (memory.within(ARM64_STOP_MMIO_ADDR, vMemory::PageSize())) {
@@ -74,6 +80,7 @@ Machine::Machine(std::string_view binary, const MachineOptions& options)
 			if (options.verbose_loader) {
 				printf("Loaded VM snapshot state\n");
 			}
+			guard.disarm(); /* Constructed: ~Machine owns it from here. */
 			return;
 		}
 		// If the file does not exist, or anything else failed, we continue
@@ -103,6 +110,8 @@ Machine::Machine(std::string_view binary, const MachineOptions& options)
 	/* Store the registers, so that Machine is ready to go */
 	this->setup_registers(regs);
 	this->set_registers(regs);
+
+	guard.disarm(); /* Constructed: ~Machine owns it from here. */
 }
 Machine::Machine(const std::vector<uint8_t>& bin, const MachineOptions& opts)
 	: Machine(bin.empty() ? std::string_view{} :
@@ -133,26 +142,26 @@ Machine::Machine(const Machine& other, const MachineOptions& options)
 		throw MachineException("Source Machine is not prepared for forking");
 	}
 
-	/* A seat is consumed permanently by the group if it is not handed back,
-	   so any failure after acquisition must return it. */
-	struct SeatGuard {
-		Machine* machine = nullptr;
-		~SeatGuard() {
-			if (UNLIKELY(machine != nullptr))
-				machine->release_group_seat();
-		}
-	} seat_guard;
+	/* A seat is consumed permanently by the group if it is not handed back and
+	   an unpooled fork's VM fd is leaked outright, so any failure after
+	   acquisition -- and every step below can throw, setup_cow_mode() running
+	   out of working memory being the usual one -- must release them.
+	   See Machine::CtorGuard. */
+	CtorGuard guard;
 
 	if (options.vm_group) {
 		/* Armed before acquisition: release_group_seat() is a no-op until a
 		   seat is actually held, and pooled_fork_prepare() can throw after
 		   taking one. */
-		seat_guard.machine = this;
+		guard.machine = this;
+		guard.group_seat = true;
 		this->pooled_fork_prepare(other, options);
 	} else {
 		/* Unfortunately we have to create a new VM because
 		   memory is tied to VMs and not vCPUs. */
 		this->fd = create_kvm_vm();
+		guard.machine = this;
+		guard.vm_fd = true;
 
 		/* Reuse pre-CoWed pagetable from the master machine */
 		this->install_memory(0, memory.vmem(), false);
@@ -200,7 +209,23 @@ Machine::Machine(const Machine& other, const MachineOptions& options)
 	this->set_registers(m_regs);
 	this->set_fpu_registers(other.prepared_fpu_registers());
 
-	seat_guard.machine = nullptr;
+	guard.disarm(); /* Constructed: ~Machine owns it from here. */
+}
+
+Machine::CtorGuard::~CtorGuard() noexcept
+{
+	if (LIKELY(this->machine == nullptr))
+		return;
+	if (this->group_seat) {
+		/* A no-op until a seat is actually held. Also detaches the vCPU from
+		   the seat, so the ~vCPU that follows this guard sees nothing of the
+		   seat's to release. */
+		this->machine->release_group_seat();
+	}
+	if (this->vm_fd && this->machine->fd >= 0) {
+		close(this->machine->fd);
+		this->machine->fd = -1;
+	}
 }
 
 void Machine::pooled_fork_prepare(const Machine& other, const MachineOptions& options)

--- a/lib/tinykvm/machine.hpp
+++ b/lib/tinykvm/machine.hpp
@@ -439,6 +439,25 @@ private:
 	   partition. Hands the seat back on any later failure (release_seat). */
 	void pooled_fork_prepare(const Machine& other, const MachineOptions&);
 	void release_group_seat() noexcept;
+	/* Releases what a constructor has already acquired when a later step
+	   throws. ~Machine is never run for a constructor that threw, so without
+	   this the VM fd and (for a pooled fork) the group seat are leaked outright
+	   -- the seat permanently, since a struct kvm never gives vCPU capacity
+	   back. Each flag is armed as its resource is taken and the whole guard is
+	   disarmed on every successful exit, early returns included.
+
+	   The vCPU's own fd, timer and kvm_run mapping are deliberately not here:
+	   vcpu is a member, so ~vCPU runs on the throwing path and releases them
+	   itself. This guard is a ctor-body local and therefore destroyed *before*
+	   any member, which is also what makes the ordering work for a pooled
+	   fork: the seat is handed back before ~vCPU could look at it. */
+	struct CtorGuard {
+		Machine* machine = nullptr;
+		bool vm_fd = false;
+		bool group_seat = false;
+		~CtorGuard() noexcept;
+		void disarm() noexcept { this->machine = nullptr; }
+	};
 	[[noreturn]] static void machine_exception(const char*, uint64_t = 0);
 	[[noreturn]] static void timeout_exception(const char*, uint32_t = 0);
 	void smp_vcpu_broadcast(std::function<void(vCPU&)>);

--- a/lib/tinykvm/vcpu.cpp
+++ b/lib/tinykvm/vcpu.cpp
@@ -153,6 +153,8 @@ void vCPU::init(int kvm_vcpu_id, int guest_cpu_index, Machine& machine, const Ma
 	this->guest_cpu_index = guest_cpu_index;
 	this->last_fault_address = 0;
 	this->m_machine = &machine;
+	/* Not a seat: everything acquired below is this vCPU's to release. */
+	this->m_seat_borrowed = false;
 	if (this->fd < 0) {
 		this->fd = ioctl(machine.fd, KVM_CREATE_VCPU, this->kvm_vcpu_id);
 		if (UNLIKELY(this->fd < 0)) {
@@ -241,6 +243,10 @@ void vCPU::init_from_seat(VmGroupSeat& seat, Machine& machine,
 	this->guest_cpu_index = 0;
 	this->last_fault_address = 0;
 	this->m_machine = &machine;
+	/* Armed before anything is taken: from here on fd, kvm_run and the timer
+	   are the seat's, and ~vCPU must not close, unmap or delete any of them
+	   however this function exits. */
+	this->m_seat_borrowed = true;
 
 	/* The seat's vCPU was created when the group materialized the seat, and is
 	   adopted by every tenant after that; it is never closed while the group
@@ -334,6 +340,7 @@ void vCPU::detach_to_seat(VmGroupSeat& seat) noexcept
 	this->m_shadow_regs = nullptr;
 	this->m_shadow_dirty_regs = 0;
 	this->m_initialized = false;
+	this->m_seat_borrowed = false;
 }
 
 void vCPU::init_extended_state(Machine& machine)
@@ -456,26 +463,49 @@ void vCPU::smp_init(int id, Machine& machine)
 	this->set_special_registers(sregs);
 }
 
+/* Idempotent, and clears every field it releases: ~vCPU calls it a second time
+   for the objects ~Machine never reaches. */
 void vCPU::deinit()
 {
-	if (this->fd > 0) {
+	if (this->fd >= 0) {
 		close(this->fd);
+		this->fd = -1;
 	}
 	/* A never-run lazy fork has nothing to unmap. Never unmap anywhere else
 	   than here: munmap fires an mmu-notifier invalidation to every VM
 	   registered in this address space. */
 	if (kvm_run != nullptr) {
 		munmap(kvm_run, vcpu_mmap_size);
+		kvm_run = nullptr;
+		/* They pointed into the mapping (adopt_kvm_run). */
+		this->m_regs  = nullptr;
+		this->m_sregs = nullptr;
 	}
 	delete (ShadowRegisters *)this->m_shadow_regs;
 	this->m_shadow_regs = nullptr;
+	this->m_shadow_dirty_regs = 0;
 
-	timer_delete(this->timer_id);
+	if (this->timer_id != nullptr) {
+		timer_delete((timer_t)this->timer_id);
+		this->timer_id = nullptr;
+		this->timer_tid = 0;
+	}
+	this->m_initialized = false;
 }
 
 vCPU::~vCPU()
 {
-	delete (ShadowRegisters *)this->m_shadow_regs;
+	/* See the declaration: this is the release path for a Machine constructor
+	   that threw after vCPU bring-up, where ~Machine (and therefore deinit())
+	   never runs. A seat's fd/kvm_run/timer are not ours to release. */
+	if (!this->m_seat_borrowed) {
+		this->deinit();
+	} else {
+		/* Shadow registers are the tenant's own even when the rest is
+		   borrowed, and detach_to_seat() is what normally frees them. */
+		delete (ShadowRegisters *)this->m_shadow_regs;
+		this->m_shadow_regs = nullptr;
+	}
 }
 
 const tinykvm_x86regs& vCPU::registers() const

--- a/lib/tinykvm/vcpu.hpp
+++ b/lib/tinykvm/vcpu.hpp
@@ -25,13 +25,20 @@ namespace tinykvm
 		   is consumed permanently by every vCPU ever created in it, so
 		   closing the fd would burn the seat instead of freeing it. */
 		void detach_to_seat(VmGroupSeat&) noexcept;
-#if !defined(TINYKVM_ARCH_ARM64)
-		/* Releases the shadow registers of a vCPU that never became mapped.
-		   deinit() is only reached from ~Machine, which is never run for a
-		   constructor that threw after vCPU init (eg. a fork that ran out of
-		   working memory in setup_cow_mode). */
+		/* Releases everything this vCPU still owns: the KVM_CREATE_VCPU fd, the
+		   POSIX execution timer, the kvm_run mapping and (AMD64) the shadow
+		   registers of a vCPU that never became mapped.
+
+		   It exists because deinit() is only reached from ~Machine, and
+		   ~Machine is never run for a *constructor* that threw after vCPU
+		   bring-up -- e.g. a fork that ran out of working memory in
+		   setup_cow_mode(), which is downstream of both KVM_CREATE_VCPU and
+		   timer_create(). deinit() clears every field it releases, so on the
+		   normal path this destructor finds nothing left to do.
+
+		   A vCPU borrowing a VM group seat (m_seat_borrowed) releases nothing:
+		   see that member. */
 		~vCPU();
-#endif
 		tinykvm_regs& registers();
 		const tinykvm_regs& registers() const;
 		void set_registers(const struct tinykvm_regs &);
@@ -96,6 +103,16 @@ namespace tinykvm
 		   (SIGEV_THREAD_ID) and vCPU::detach_to_seat(). */
 		pid_t timer_tid = 0;
 		void* timer_id = nullptr;
+		/* Set while fd, kvm_run and timer_id are on loan from a VM group seat
+		   rather than owned: init_from_seat() borrows all three and
+		   detach_to_seat() hands them back. ~vCPU releases nothing while it is
+		   set — the seat keeps all three for its next tenant, and closing the
+		   fd would burn the group's permanently-consumed vCPU capacity instead
+		   of freeing it. It is not the leak-safety mechanism for a pooled
+		   member (the constructor's seat guard is, and it runs first, before
+		   any member destructor); it is what makes ~vCPU safe if that ever
+		   stops being true. */
+		bool m_seat_borrowed = false;
 		uint64_t last_fault_address = 0;
 		uint64_t remote_return_address = 0;
 		uint64_t remote_original_tls_base = 0;

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -27,6 +27,12 @@ function(add_unit_test NAME)
 	)
 endfunction()
 
+# Arch-neutral: the resource-ownership rules it pins (a throwing fork
+# constructor releases what it took; a pooled one hands its seat back instead)
+# are the same on both backends, and both have their own copy of the vCPU
+# bring-up code that has to obey them.
+add_unit_test(fork_ctor_leak fork_ctor_leak.cpp)
+
 if (TINYKVM_ARCH STREQUAL "AMD64")
 	add_unit_test(basic  basic.cpp)
 	add_unit_test(elf    elf.cpp)

--- a/tests/unit/arm64_elf.cpp
+++ b/tests/unit/arm64_elf.cpp
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <vector>
+#include <unistd.h> /* access(), R_OK -- not pulled in transitively by GCC 16 */
 #include <tinykvm/machine.hpp>
 
 extern std::vector<uint8_t> build_and_load(const std::string& code);

--- a/tests/unit/fork_ctor_leak.cpp
+++ b/tests/unit/fork_ctor_leak.cpp
@@ -1,0 +1,192 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdio>
+#include <cstring>
+#include <dirent.h>
+#include <string>
+#include <unistd.h>
+#include <vector>
+#include <tinykvm/machine.hpp>
+
+/* The fork constructor acquires the vCPU fd and the vCPU's POSIX timer, and
+   only *then* reaches steps that can throw -- setup_cow_mode() runs out of
+   working memory being the documented one. ~Machine is never run for a
+   constructor that threw, so anything the vCPU still holds at that point is
+   leaked unless the vCPU itself releases it. That is what this file pins:
+   a few thousand failing constructions must return the process to its
+   starting fd count and its starting POSIX-timer count.
+
+   Both counts are read out of /proc/self, which is where the leak is actually
+   visible; and the loop is long enough that a leaked fd would blow the
+   default RLIMIT_NOFILE (1024) on its own, turning the expected
+   "Out of working memory" into a KVM_CREATE_VCPU failure -- so the exception
+   *message* is asserted too, and stays a valid check on a host with a large
+   fd limit where the counting alone would still pass. */
+
+extern std::vector<uint8_t> build_and_load(const std::string& code);
+
+static const uint64_t MAX_MEMORY = 32ul << 20; /* 32MB */
+static const uint64_t MAX_COWMEM =  4ul << 20; /* 4MB */
+/* Enough that a one-fd-per-iteration leak exhausts the default 1024-fd
+   RLIMIT_NOFILE several times over, while still running in well under a
+   second (no KVM_RUN happens on this path). */
+static constexpr int FAILING_FORKS = 4000;
+static const std::vector<std::string> env {
+	"LC_TYPE=C", "LC_ALL=C", "USER=root"
+};
+
+static void require_kvm()
+{
+	static bool attempted = false;
+	static bool available = false;
+	static std::string error;
+	if (!attempted) {
+		attempted = true;
+		try {
+			tinykvm::Machine::init();
+			available = true;
+		} catch (const tinykvm::MachineException& e) {
+			error = std::string(e.what()) + " (" + std::to_string(e.data()) + ")";
+		}
+	}
+	if (!available) {
+		SKIP("KVM unavailable: " << error);
+	}
+}
+
+/* Every open fd of this process, KVM's or not: the leak is a vCPU fd, but
+   counting all of them keeps the check honest about anything else the failed
+   construction forgot to close. */
+static size_t count_open_fds()
+{
+	DIR* dir = opendir("/proc/self/fd");
+	REQUIRE(dir != nullptr);
+	size_t count = 0;
+	while (const struct dirent* entry = readdir(dir)) {
+		if (entry->d_name[0] == '.')
+			continue;
+		count += 1;
+	}
+	closedir(dir);
+	return count;
+}
+
+/* POSIX timers are not fds and do not show up above -- /proc/self/timers is
+   the only place a timer_create() that was never timer_delete()d is visible.
+   One "ID:" line per live timer. */
+static size_t count_posix_timers()
+{
+	FILE* f = fopen("/proc/self/timers", "r");
+	if (f == nullptr) {
+		/* CONFIG_CHECKPOINT_RESTORE=n. The fd half still runs. */
+		return SIZE_MAX;
+	}
+	size_t count = 0;
+	char line[256];
+	while (fgets(line, sizeof(line), f) != nullptr) {
+		if (strncmp(line, "ID:", 3) == 0)
+			count += 1;
+	}
+	fclose(f);
+	return count;
+}
+
+/* A master parked at its entry point, forkable. Built once: the guest is
+   irrelevant to this test -- no fork here ever runs -- and compiling it 4000
+   times would dominate the runtime. */
+static tinykvm::Machine& forkable_master()
+{
+	static std::vector<uint8_t> binary = build_and_load(R"M(
+int main() { return 0; }
+)M");
+	static tinykvm::Machine machine { binary, { .max_mem = MAX_MEMORY } };
+	static bool prepared = false;
+	if (!prepared) {
+		prepared = true;
+		machine.setup_linux({"leak"}, env);
+		machine.run(8.0f);
+		machine.prepare_copy_on_write();
+	}
+	return machine;
+}
+
+/* max_cow_mem = 0 leaves the fork's memory banks with a ceiling of zero
+   pages, so the very first new_page() in setup_cow_mode() throws -- which is
+   after vCPU::init()/init_from_seat() has taken the fd and the timer, i.e.
+   exactly the window this test is about. */
+static tinykvm::MachineOptions failing_fork_options(bool pooled)
+{
+	tinykvm::MachineOptions options;
+	options.max_mem = MAX_MEMORY;
+	options.max_cow_mem = 0;
+	options.vm_group = pooled;
+	return options;
+}
+
+TEST_CASE("A throwing fork constructor leaks no vCPU fd or POSIX timer", "[fork][leak]")
+{
+	require_kvm();
+	auto& master = forkable_master();
+	REQUIRE(master.is_forkable());
+
+	/* One throwing construction first, so any one-time allocation it makes
+	   (the timer's signal handler, /proc opens, ...) is already accounted for
+	   in the baseline and cannot be mistaken for a leak. */
+	REQUIRE_THROWS(tinykvm::Machine{master, failing_fork_options(false)});
+
+	const size_t fds_before = count_open_fds();
+	const size_t timers_before = count_posix_timers();
+
+	for (int i = 0; i < FAILING_FORKS; i++) {
+		bool threw = false;
+		try {
+			tinykvm::Machine fork {master, failing_fork_options(false)};
+			(void)fork;
+		} catch (const tinykvm::MemoryException& e) {
+			threw = true;
+			/* Not "Failed to KVM_CREATE_VCPU"/"Unable to create timeout
+			   timer": the fork must still be failing for the reason the test
+			   arranged, not because a leak exhausted a limit. */
+			REQUIRE(std::string(e.what()) == "Out of working memory");
+		}
+		REQUIRE(threw);
+	}
+
+	REQUIRE(count_open_fds() == fds_before);
+	if (timers_before != SIZE_MAX) {
+		REQUIRE(count_posix_timers() == timers_before);
+	}
+}
+
+/* The pooled twin. A VM group seat owns its vCPU fd and its timer for the
+   life of the group and hands them to each tenant in turn, so the release the
+   test above demands must NOT happen here: a member whose constructor throws
+   has to give the seat back intact. Both halves of that are checked -- no
+   growth across the failing loop (the seat is returned, not burned), and a
+   working fork afterwards (the fd was handed back, not closed). */
+TEST_CASE("A throwing pooled fork constructor returns its seat intact", "[fork][leak][vm_group]")
+{
+	require_kvm();
+	auto& master = forkable_master();
+	REQUIRE(master.is_forkable());
+
+	REQUIRE_THROWS(tinykvm::Machine{master, failing_fork_options(true)});
+
+	const size_t fds_before = count_open_fds();
+	const size_t timers_before = count_posix_timers();
+
+	for (int i = 0; i < FAILING_FORKS; i++) {
+		REQUIRE_THROWS(tinykvm::Machine{master, failing_fork_options(true)});
+	}
+
+	REQUIRE(count_open_fds() == fds_before);
+	if (timers_before != SIZE_MAX) {
+		REQUIRE(count_posix_timers() == timers_before);
+	}
+
+	/* The seat survived every failure: it can still be taken and used. */
+	tinykvm::MachineOptions good = failing_fork_options(true);
+	good.max_cow_mem = MAX_COWMEM;
+	tinykvm::Machine fork {master, good};
+	REQUIRE(fork.is_forked());
+}


### PR DESCRIPTION
## leak

A `Machine` constructor takes `KVM_CREATE_VCPU`'s fd and the vCPU's POSIX execution timer well before it reaches anything that can fail. `setup_cow_mode()` running out of working memory is the documented one on the fork path; the ELF loader is the equivalent on the master path. `~Machine` is never run for a constructor that threw, and `~Machine` is the only caller of `vCPU::deinit()` — so the fd, the timer and the `kvm_run` mapping all leaked. Only the shadow-register allocation was covered, by the `~vCPU` that the lazy-`kvm_run` work added.

Measured on the branch point: 4000 failing forks leak **8013 fds** (two per fork) and **4002 POSIX timers**.

The second fd per fork is the **VM fd**: an unpooled fork calls `create_kvm_vm()` and nothing but `~Machine` closes it. Same bug, same code path, so it is fixed here rather than left for a follow-up.

## The fix

Widen the mechanism that already exists rather than adding a second one.

- **`~vCPU` now exists on both arches and calls `deinit()`**, which is made idempotent and clears every field it releases. The normal path (`~Machine` → `deinit`) therefore leaves the destructor nothing to do; the throwing path is covered by the member destructor, which *does* run.
- **`vCPU::m_seat_borrowed`** marks the window in which `fd`/`kvm_run`/`timer_id` belong to a VM group seat rather than to the vCPU, so `~vCPU` releases none of them — closing a seat's fd would burn the group's permanently-consumed vCPU capacity instead of freeing it. This is not what makes a pooled member leak-safe (the constructor guard below still runs first, before any member destructor); it is what keeps `~vCPU` correct if that ordering ever changes.
- **`Machine::CtorGuard`** replaces the fork constructor's local `SeatGuard` and additionally covers the VM fd, on *both* constructors — including the master constructor's early return on the snapshot-load path.

Two adjacent nits found on the way, both ARM64: three `mmap` sites stored `MAP_FAILED` into `this->kvm_run` before throwing, which the new destructor would have taken for a live mapping and `munmap((void*)-1)`; they now assign only on success. And `init_from_seat()`'s failing mmap no longer leaves `MAP_FAILED` on the seat for its next tenant to adopt.

Falls out for free: SMP vCPUs (`SMP::MPvCPU`) were never `deinit()`ed at all — `~MPvCPU` is empty — so they leaked an fd and a timer per SMP vCPU for the machine's whole life. `~vCPU` now covers them.

## Test

`tests/unit/fork_ctor_leak.cpp`, arch-neutral and registered for both backends.

1. *A throwing fork constructor leaks no vCPU fd or POSIX timer* — 4000 constructions that throw in `setup_cow_mode()` (`max_cow_mem = 0`), asserting the process's fd count (`/proc/self/fd`) and POSIX-timer count (`/proc/self/timers`) are unchanged, and that the failure is still the arranged `Out of working memory` rather than an exhausted limit. Both halves were confirmed to fail without their fix: **8013 vs 13** fds, **4002 vs 2** timers.
2. *A throwing pooled fork constructor returns its seat intact* — the opposite ownership rule: no growth across the same loop (the seat is returned, not burned) and a working fork afterwards (the fd was handed back, not closed).

`/proc/self/timers` needs `CONFIG_CHECKPOINT_RESTORE`; the timer half self-skips without it, the fd half still runs.

## Verification

- **ARM64 (this host, real `/dev/kvm`, Fedora Asahi / GCC 16):** full unit suite green, new test included.
- **AMD64:** compile-checked only (no x86 host available) — the full AMD64 source list built with `-Wall -Wextra` under an x86_64 container, clean, plus a syntax check of the new test TU. The AMD64 KVM tests could not be *run*; they should be before merge.
- The first commit is an unrelated one-line build fix: `arm64_elf.cpp` uses `access()`/`R_OK` without including `<unistd.h>`, which GCC 16 no longer supplies transitively, so the TU did not build and CTest reported `test_arm64_elf` as "Not Run" — indistinguishable from a skip. With it building again, one of its cases (*ARM64 runs a dynamic Python guest*, `writable_page_at: l2 entry not writable`) **fails on this host**. That failure is pre-existing and unrelated — it reproduces on the unmodified branch — and is simply no longer hidden. Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
