### PR TITLE
test: cross-process fork, SMP x lazy kvm_run, fork-path TLS base coverage

### DIFF
--- a/tests/unit/arm64_elf.cpp
+++ b/tests/unit/arm64_elf.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <string>
+#include <unistd.h>
 #include <vector>
 #include <tinykvm/machine.hpp>
 

--- a/tests/unit/arm64_fork.cpp
+++ b/tests/unit/arm64_fork.cpp
@@ -5,6 +5,9 @@
 #include <utility>
 #include <vector>
 #include <tinykvm/machine.hpp>
+#include <tinykvm/linux/threads.hpp>
+#include <sys/wait.h>
+#include <unistd.h>
 
 extern std::pair<std::string, std::vector<uint8_t>>
 	build_and_load(const std::string& code, const std::string& args);
@@ -112,4 +115,202 @@ extern long cow_check(void) {
 
 	fork.timed_vmcall(func, 8.0f);
 	REQUIRE(fork.return_value() == BUF_PAGES);
+}
+
+// Regression test for the cross-process master path (fast-agent issue #18),
+// fixed on ARM64 by tinykvm#114 -- see that PR and docs/architecture/
+// process-per-vm.md for the fd/ownership contract this locks in.
+//
+// --process-per-vm boots one master and fork()s a zygote; every worker then
+// constructs its own TinyKVM fork of the inherited master from a *different*
+// process than the one that built it. KVM binds a VM to the creating
+// process's mm: any vCPU ioctl issued against the master's fd from another
+// process fails with -EIO. Before tinykvm#114, setup_cow_mode() read five
+// EL1 sysregs (MAIR/TCR/SCTLR/CPACR/VBAR) straight off the master's vcpu fd,
+// and the constructor's other.registers() could fall back to the same fd
+// whenever its register cache was cold -- both fine in-process, both -EIO
+// from a worker, so *no* fork could be built on ARM64 and every turn failed
+// (fast-agent issue #66). The fix snapshots that state
+// (prepared_sysregs()/warmed register cache) into the master at
+// prepare_copy_on_write() time, while its fd is still ioctl-able, so a
+// worker never has to touch it.
+//
+// Masters "stay eager by construction": nothing about consuming a master
+// from a different process should depend on state that was lazily faulted
+// in and therefore never crossed the process boundary. Mirroring the real
+// topology precisely (run() + prepare_copy_on_write() happen once, in the
+// single-threaded parent, before the OS-level fork() below) is what makes
+// this a faithful regression guard rather than a synthetic one.
+TEST_CASE("ARM64 cross-process master path: a worker builds and runs its own fork", "[arm64][fork]")
+{
+	require_arm64_kvm();
+
+	const auto [program, binary] = build_and_load(R"M(
+int main() {
+}
+static int value = 0;
+extern int get_value() {
+	value++;
+	return value;
+})M", "");
+
+	// 16K-page hosts need CoW pages split down from the paging library's
+	// default block size for writable_page_at() to find a writable leaf
+	// entry (see the other fork/reset options in this file and in
+	// arm64_minimal.cpp -- every one of them sets this).
+	const tinykvm::MachineOptions options {
+		.max_mem = MAX_MEMORY, .max_cow_mem = MAX_COWMEM,
+		.split_hugepages = true,
+	};
+
+	tinykvm::Machine machine { binary, options };
+	machine.setup_linux({"fork"}, env);
+	// Everything the fork constructor needs from the master must be settled
+	// here, in the single-threaded parent, before the OS-level fork() below.
+	machine.run(4.0f);
+	machine.prepare_copy_on_write(65536);
+
+	const auto get_value = machine.address_of("get_value");
+	REQUIRE(get_value != 0x0);
+
+	struct WorkerResult {
+		bool constructed = false;
+		bool ran_ok = false;
+		bool reset_ok = false;
+		bool ran_again_ok = false;
+		long value1 = -1;
+		long value2 = -1;
+		char error[256] = {0};
+	};
+
+	int pipefd[2];
+	REQUIRE(pipe(pipefd) == 0);
+
+	fflush(nullptr);
+	const pid_t pid = fork();
+	REQUIRE(pid >= 0);
+
+	if (pid == 0) {
+		// Worker process: never touches the parent's `machine` object again
+		// except through the state that crossed fork() -- no ioctl on the
+		// master's vcpu fd is possible here (KVM binds the VM to the
+		// creating process's mm), so any regression back to a live read of
+		// `other`'s fd fails loudly with -EIO instead of silently.
+		close(pipefd[0]);
+		WorkerResult result{};
+		try {
+			tinykvm::Machine fork_vm { machine, options };
+			result.constructed = true;
+
+			fork_vm.timed_vmcall(get_value, 4.0f);
+			result.value1 = fork_vm.return_value();
+			result.ran_ok = (result.value1 == 1);
+
+			// The process-per-vm worker lifecycle recycles across tenants via
+			// reset_to() (process-per-vm.md, "Worker lifetime policy") --
+			// still cross-process, still must not touch the master's fd.
+			fork_vm.reset_to(machine, options);
+			result.reset_ok = true;
+
+			fork_vm.timed_vmcall(get_value, 4.0f);
+			result.value2 = fork_vm.return_value();
+			result.ran_again_ok = (result.value2 == 1);
+		} catch (const std::exception& e) {
+			strncpy(result.error, e.what(), sizeof(result.error) - 1);
+		}
+		[[maybe_unused]] const ssize_t w = write(pipefd[1], &result, sizeof(result));
+		close(pipefd[1]);
+		_exit(0);
+	}
+
+	close(pipefd[1]);
+	WorkerResult result{};
+	const ssize_t r = read(pipefd[0], &result, sizeof(result));
+	close(pipefd[0]);
+
+	int status = 0;
+	REQUIRE(waitpid(pid, &status, 0) == pid);
+	REQUIRE(WIFEXITED(status));
+	REQUIRE(WEXITSTATUS(status) == 0);
+
+	REQUIRE(r == (ssize_t) sizeof(result));
+	INFO("worker error: " << result.error);
+	REQUIRE(result.constructed);
+	REQUIRE(result.ran_ok);
+	REQUIRE(result.value1 == 1);
+	REQUIRE(result.reset_ok);
+	REQUIRE(result.ran_again_ok);
+	REQUIRE(result.value2 == 1);
+
+	// The master itself is unharmed: it is still forkable in the parent, and
+	// a fresh fork built here (in-process this time) behaves identically.
+	auto fork_in_parent = tinykvm::Machine { machine, options };
+	fork_in_parent.timed_vmcall(get_value, 4.0f);
+	REQUIRE(fork_in_parent.return_value() == 1);
+}
+
+// Regression test for the fork-path set_tls_base seat/tid coupling (fast-agent
+// issue #20), ARM64 side. MultiThreading::reset_to (lib/tinykvm/arm64/
+// stubs.cpp) is unconditional on this arch -- unlike x86_64 it does not
+// compare the fork's default tid (1) against the master's current one -- but
+// it is the *only* place a fork's tpidr_el0 is ever set: ARM64's
+// setup_cow_mode() only carries the five CoW-relevant EL1 sysregs (MAIR/TCR/
+// SCTLR/CPACR/VBAR, see tinykvm#114) and never touches TPIDR_EL0. So this is
+// not a redundant safety net the way it can be on x86_64 (whose setup_cow_mode
+// also blanket-copies sregs, including FS/GS base, from the same master): if
+// a master ever touched threads() and its current thread id is not 1, the
+// fork's TLS base depends entirely on this call reading the right Thread
+// record. Read it back with Machine::tpidr_el0() -- the helper named in
+// AGENTS.md, which always issues a fresh KVM_GET_ONE_REG ioctl, no userspace
+// cache to fool.
+TEST_CASE("ARM64 fork inherits tpidr_el0 from master's non-default current thread", "[arm64][fork][threads]")
+{
+	require_arm64_kvm();
+
+	const auto [program, binary] = build_and_load(R"M(
+int main() {
+}
+extern int get_value() {
+	return 42;
+})M", "");
+
+	tinykvm::Machine machine { binary, { .max_mem = MAX_MEMORY } };
+	machine.setup_linux({"fork"}, env);
+	machine.run(4.0f);
+
+	static constexpr uint64_t TLS_MARKER = 0x0000133700001337ULL;
+	static constexpr int NON_DEFAULT_TID = 7;
+
+	// Master's calling thread is not the default tid (1) when it is
+	// snapshotted. MultiThreading::reset_to() on this arch reads the Thread
+	// record's own cached fsbase field directly (not a live register), so
+	// that field -- not just the live tpidr_el0 -- must carry the marker.
+	auto& thread = machine.threads().create(NON_DEFAULT_TID);
+	thread.fsbase = TLS_MARKER;
+	machine.threads().set_to_and_suspend_others(NON_DEFAULT_TID);
+	machine.set_tls_base(TLS_MARKER);
+	REQUIRE(machine.threads().gettid() == NON_DEFAULT_TID);
+	REQUIRE(machine.tpidr_el0() == TLS_MARKER);
+
+	machine.prepare_copy_on_write(65536);
+
+	auto fork = tinykvm::Machine { machine, {
+		.max_mem = MAX_MEMORY, .max_cow_mem = MAX_COWMEM
+	}};
+
+	// The fork's own thread bookkeeping followed the master's current
+	// thread, not the default tid=1 every fresh MultiThreading starts with.
+	REQUIRE(fork.threads().gettid() == NON_DEFAULT_TID);
+
+	// tpidr_el0() always issues a fresh KVM_GET_ONE_REG ioctl -- already the
+	// strongest possible confirmation, and correct before the fork ever runs.
+	REQUIRE(fork.tpidr_el0() == TLS_MARKER);
+
+	const auto get_value = fork.address_of("get_value");
+	REQUIRE(get_value != 0x0);
+	fork.timed_vmcall(get_value, 4.0f);
+	REQUIRE(fork.return_value() == 42);
+
+	// Still correct straight off the hardware register after running.
+	REQUIRE(fork.tpidr_el0() == TLS_MARKER);
 }

--- a/tests/unit/fork.cpp
+++ b/tests/unit/fork.cpp
@@ -2,6 +2,12 @@
 #include <catch2/matchers/catch_matchers_string.hpp>
 
 #include <tinykvm/machine.hpp>
+#include <tinykvm/linux/threads.hpp>
+#include <cstring>
+#include <linux/kvm.h> /* struct kvm_sregs */
+#include <sys/ioctl.h>
+#include <sys/wait.h>
+#include <unistd.h>
 extern std::vector<uint8_t> build_and_load(const std::string& code);
 static const uint64_t MAX_MEMORY = 8ul << 20; /* 8MB */
 static const uint64_t MAX_COWMEM = 3ul << 20; /* 3MB */
@@ -856,4 +862,205 @@ int func2() {
 			.reset_keep_all_work_memory = true
 		});
 	}
+}
+
+/* Regression test for the cross-process master path (fast-agent issue #18,
+   fixed on ARM64 by tinykvm#114). --process-per-vm boots one master and
+   fork()s a zygote; every worker then constructs its own TinyKVM fork of the
+   inherited master from a *different* process than the one that built it.
+   KVM binds a VM to the creating process's mm (docs/architecture/
+   process-per-vm.md, fact 1): any vCPU ioctl issued against the master's fd
+   from another process fails with -EIO. The fork constructor and reset_to()
+   must therefore never ioctl `other`'s vcpu fd -- everything they need (GPRs
+   and sregs via the synced-regs page, FPU via the prepare-time snapshot) must
+   already be readable from userspace state that crossed the fork() boundary.
+   This is exactly the property that broke on ARM64 before tinykvm#114:
+   setup_cow_mode() read five EL1 sysregs straight off the master's vcpu fd,
+   and the constructor's other.registers() could fall back to the same fd
+   whenever the register cache was cold -- both fine in-process, both -EIO
+   from a worker. The fix snapshots that state into the master at
+   prepare_copy_on_write() time, while its fd is still ioctl-able, so the
+   worker never has to touch it.
+
+   Masters "stay eager by construction": nothing about consuming a master
+   from a different process should depend on state that was lazily faulted in
+   and therefore never crossed the process boundary. Mirroring the real
+   topology precisely (run() + prepare_copy_on_write() happen once, in the
+   single-threaded parent, before the OS-level fork() -- see process-per-vm.md
+   fact 4) is what makes this a faithful regression guard rather than a
+   synthetic one. */
+TEST_CASE("Cross-process master path: a worker builds and runs its own fork", "[Fork]")
+{
+	const auto binary = build_and_load(R"M(
+int main() {
+}
+static int value = 0;
+extern int get_value() {
+	value++;
+	return value;
+})M");
+
+	tinykvm::Machine machine { binary, { .max_mem = MAX_MEMORY } };
+	machine.setup_linux({"fork"}, env);
+	// Everything the fork constructor needs from the master must be settled
+	// here, in the single-threaded parent, before the OS-level fork() below.
+	machine.run(4.0f);
+	machine.prepare_copy_on_write(65536);
+
+	const auto get_value = machine.address_of("get_value");
+	REQUIRE(get_value != 0x0);
+
+	struct WorkerResult {
+		bool constructed = false;
+		bool ran_ok = false;
+		bool reset_ok = false;
+		bool ran_again_ok = false;
+		long value1 = -1;
+		long value2 = -1;
+		char error[256] = {0};
+	};
+
+	int pipefd[2];
+	REQUIRE(pipe(pipefd) == 0);
+
+	fflush(nullptr);
+	const pid_t pid = fork();
+	REQUIRE(pid >= 0);
+
+	if (pid == 0) {
+		/* Worker process: never touches the parent's `machine` object again
+		   except through the state that crossed fork() -- no ioctl on the
+		   master's vcpu fd is possible here (KVM binds the VM to the
+		   creating process's mm), so any regression back to a live read of
+		   `other`'s fd fails loudly with -EIO instead of silently. */
+		close(pipefd[0]);
+		WorkerResult result{};
+		try {
+			tinykvm::Machine fork_vm { machine, {
+				.max_mem = MAX_MEMORY, .max_cow_mem = MAX_COWMEM
+			}};
+			result.constructed = true;
+
+			fork_vm.timed_vmcall(get_value, 4.0f);
+			result.value1 = fork_vm.return_value();
+			result.ran_ok = (result.value1 == 1);
+
+			/* The process-per-vm worker lifecycle recycles across tenants via
+			   reset_to() (process-per-vm.md, "Worker lifetime policy") --
+			   still cross-process, still must not touch the master's fd. */
+			fork_vm.reset_to(machine, {
+				.max_mem = MAX_MEMORY, .max_cow_mem = MAX_COWMEM
+			});
+			result.reset_ok = true;
+
+			fork_vm.timed_vmcall(get_value, 4.0f);
+			result.value2 = fork_vm.return_value();
+			result.ran_again_ok = (result.value2 == 1);
+		} catch (const std::exception& e) {
+			strncpy(result.error, e.what(), sizeof(result.error) - 1);
+		}
+		[[maybe_unused]] const ssize_t w = write(pipefd[1], &result, sizeof(result));
+		close(pipefd[1]);
+		_exit(0);
+	}
+
+	close(pipefd[1]);
+	WorkerResult result{};
+	const ssize_t r = read(pipefd[0], &result, sizeof(result));
+	close(pipefd[0]);
+
+	int status = 0;
+	REQUIRE(waitpid(pid, &status, 0) == pid);
+	REQUIRE(WIFEXITED(status));
+	REQUIRE(WEXITSTATUS(status) == 0);
+
+	REQUIRE(r == (ssize_t) sizeof(result));
+	INFO("worker error: " << result.error);
+	REQUIRE(result.constructed);
+	REQUIRE(result.ran_ok);
+	REQUIRE(result.value1 == 1);
+	REQUIRE(result.reset_ok);
+	REQUIRE(result.ran_again_ok);
+	REQUIRE(result.value2 == 1);
+
+	/* The master itself is unharmed: it is still forkable in the parent, and
+	   a fresh fork built here (in-process this time) behaves identically. */
+	auto fork_in_parent = tinykvm::Machine { machine, {
+		.max_mem = MAX_MEMORY, .max_cow_mem = MAX_COWMEM
+	}};
+	fork_in_parent.timed_vmcall(get_value, 4.0f);
+	REQUIRE(fork_in_parent.return_value() == 1);
+}
+
+/* Regression test for the fork-path set_tls_base seat/tid coupling (fast-agent
+   issue #20). docs/design/create-fork-vm-pooling.md (the "Correct design"
+   section under lever C) calls out threads.cpp:101 -- MultiThreading::reset_to
+   -- as a fork-construction call site that performs a read-modify-write of
+   the fork's sregs via set_tls_base(). That call only fires when the master's
+   *current* thread id differs from the default (1) every fresh
+   MultiThreading starts with, so the ordinary single-thread case (master
+   never touches threads() at all) never exercises it. This builds a master
+   whose current thread id is not 1 before it is snapshotted, then confirms
+   the fork's FS base lands correctly -- first via the C++ accessor (the
+   userspace synced-regs mirror, correct even before the fork ever runs), and
+   again via a raw KVM_GET_SREGS ioctl after running the fork once, so the
+   dirty synced-regs bits have actually been consumed into real vCPU state.
+   The seat is exercised at the host level via MultiThreading's public API
+   (tinykvm/linux/threads.hpp) rather than a fragile guest-side clone()
+   dance -- this is a fork-construction/reset invariant, not a scheduler
+   behavior, so it does not need real guest threading to expose it. */
+TEST_CASE("Fork inherits FS base from master's non-default current thread", "[Fork][Threads]")
+{
+	const auto binary = build_and_load(R"M(
+int main() {
+}
+extern int get_value() {
+	return 42;
+})M");
+
+	tinykvm::Machine machine { binary, { .max_mem = MAX_MEMORY } };
+	machine.setup_linux({"fork"}, env);
+	machine.run(4.0f);
+
+	static constexpr uint64_t TLS_MARKER = 0x0000133700001337ULL;
+	static constexpr int NON_DEFAULT_TID = 7;
+
+	/* Master's calling thread is not the default tid (1) when it is
+	   snapshotted, and its live FS base is the marker below. Setting the
+	   Thread record's own cached fsbase (not just the live register) matches
+	   what a real activate()/resume() would have left behind, and keeps this
+	   test meaningful on both arches (see the ARM64 twin in arm64_fork.cpp,
+	   whose reset_to() reads the Thread's cached field directly rather than
+	   re-reading a live sreg). */
+	auto& thread = machine.threads().create(NON_DEFAULT_TID);
+	thread.fsbase = TLS_MARKER;
+	machine.threads().set_to_and_suspend_others(NON_DEFAULT_TID);
+	machine.set_tls_base(TLS_MARKER);
+	REQUIRE(machine.threads().gettid() == NON_DEFAULT_TID);
+
+	machine.prepare_copy_on_write(65536);
+
+	auto fork = tinykvm::Machine { machine, {
+		.max_mem = MAX_MEMORY, .max_cow_mem = MAX_COWMEM
+	}};
+
+	/* The fork's own thread bookkeeping followed the master's current
+	   thread, not the default tid=1 every fresh MultiThreading starts with. */
+	REQUIRE(fork.threads().gettid() == NON_DEFAULT_TID);
+
+	/* Correct before the fork has ever run: get_special_registers() reads the
+	   mmap'd synced-regs page directly. */
+	REQUIRE(fork.get_special_registers().fs.base == TLS_MARKER);
+
+	const auto get_value = fork.address_of("get_value");
+	REQUIRE(get_value != 0x0);
+	fork.timed_vmcall(get_value, 4.0f);
+	REQUIRE(fork.return_value() == 42);
+
+	/* Strongest possible confirmation: a raw KVM_GET_SREGS ioctl, bypassing
+	   every userspace mirror, after KVM has consumed the dirty synced-regs
+	   bits into real vCPU state via the run above. */
+	struct kvm_sregs sregs {};
+	REQUIRE(ioctl(fork.cpu().fd, KVM_GET_SREGS, &sregs) == 0);
+	REQUIRE(sregs.fs.base == TLS_MARKER);
 }

--- a/tests/unit/lazy_kvm_run.cpp
+++ b/tests/unit/lazy_kvm_run.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <tinykvm/machine.hpp>
+#include <tinykvm/smp.hpp>
 #include <cstdio>
 #include <cstring>
 #include <linux/kvm.h> /* struct kvm_sregs */
@@ -244,4 +245,136 @@ TEST_CASE("Eagerly mapped forks map at construction", "[LazyRun]")
 	} else {
 		REQUIRE(count_vcpu_mappings() == baseline);
 	}
+}
+
+/* Regression tests for the SMP x lazy-kvm_run interaction (fast-agent issue
+   #19). docs/design/create-fork-vm-pooling.md's lever C states the lazy
+   mapping is per-vCPU bookkeeping ("map = #forks that have ever run", the
+   invariant `Only forks that have run are mapped` above already locks in for
+   single-vCPU forks); this exercises the same bookkeeping once a fork itself
+   goes SMP (real multi-vCPU via Machine::smp(), not the cooperative
+   MultiThreading green threads used for guest pthread emulation).
+
+   SMP is AMD64-only in this tree today (lib/tinykvm/arm64/stubs.cpp:
+   Machine::smp() throws "SMP is not implemented on ARM64"), so this file
+   builds only under TINYKVM_ARCH=AMD64 already (see CMakeLists.txt) and
+   there is no ARM64 counterpart to add. */
+
+static std::vector<uint8_t> smp_lazy_test_binary()
+{
+	return build_and_load(R"M(
+int main() {
+}
+static volatile long counter = 0;
+extern void bump() {
+	__sync_fetch_and_add(&counter, 1);
+}
+extern long get_counter() {
+	return counter;
+})M");
+}
+
+TEST_CASE("SMP fork lazily maps its main vCPU and eagerly maps the SMP vCPUs it brings up", "[LazyRun][SMP]")
+{
+	/* Give the *master* more than one real vCPU (via Machine::smp(), not
+	   guest-level threading) before it is snapshotted. Nothing in the design
+	   doc's lever C claims a master's own vCPU history changes anything
+	   about a fork's lazy main-vCPU mapping -- a fork always starts with
+	   exactly one vCPU (guest_cpu_index 0) regardless of what the master
+	   used, so this proves that holds even when the master itself went SMP. */
+	const auto binary = smp_lazy_test_binary();
+	tinykvm::Machine machine { binary, { .max_mem = MAX_MEMORY } };
+	machine.setup_linux({"lazy_smp"}, env);
+	machine.run(4.0f);
+
+	const auto bump = machine.address_of("bump");
+	const auto get_counter = machine.address_of("get_counter");
+	REQUIRE(bump != 0x0);
+	REQUIRE(get_counter != 0x0);
+
+	{
+		const uint64_t master_stack = machine.mmap_allocate(3 * 0x4000);
+		machine.smp().timed_smpcall(2, master_stack, 0x4000, bump, 4.0f);
+		machine.smp_wait();
+		REQUIRE(machine.smp_active_count() == 0);
+	}
+
+	machine.prepare_copy_on_write(65536);
+
+	/* Baseline is captured *after* the master's own SMP run, so it already
+	   contains the master's own (always-eager) vCPU mappings -- what matters
+	   below is the delta the fork itself introduces. */
+	const size_t baseline = count_vcpu_mappings();
+
+	tinykvm::Machine fork { machine, lazy_options() };
+
+	/* (a) Construction maps nothing: not the fork's own main vCPU, and
+	   nothing about the master's SMP history forced anything either. */
+	REQUIRE(count_vcpu_mappings() == baseline);
+
+	/* First use of the fork's own main vCPU maps exactly one kvm_run page. */
+	fork.timed_vmcall(get_counter, 4.0f);
+	REQUIRE(fork.return_value() == 2); /* inherited from the master's two bumps */
+	REQUIRE(count_vcpu_mappings() == baseline + 1);
+
+	/* (b) Bring up the fork's own SMP vCPUs and use every one of them. */
+	static constexpr size_t SMP_CPUS = 3;
+	const uint64_t fork_stack = fork.mmap_allocate((SMP_CPUS + 1) * 0x4000);
+	fork.smp().timed_smpcall(SMP_CPUS, fork_stack, 0x4000, bump, 4.0f);
+	fork.smp_wait();
+	REQUIRE(fork.smp_active_count() == 0);
+
+	fork.timed_vmcall(get_counter, 4.0f);
+	REQUIRE(fork.return_value() == 2 + (long)SMP_CPUS);
+
+	/* Secondary SMP vCPUs are only ever created in order to run immediately
+	   (vCPU::smp_init maps kvm_run eagerly at creation, unlike the lazily
+	   mapped main vCPU above -- "SMP vCPUs are only ever created in order to
+	   run", per the comment at their creation site), so bringing up SMP_CPUS
+	   of them adds exactly that many mappings: one per vCPU that has ever
+	   existed on this fork, main included. */
+	REQUIRE(count_vcpu_mappings() == baseline + 1 + SMP_CPUS);
+}
+
+TEST_CASE("SMP fork teardown releases every per-vCPU kvm_run mapping", "[LazyRun][SMP]")
+{
+	const auto binary = smp_lazy_test_binary();
+	tinykvm::Machine machine { binary, { .max_mem = MAX_MEMORY } };
+	machine.setup_linux({"lazy_smp"}, env);
+	machine.run(4.0f);
+	machine.prepare_copy_on_write(65536);
+
+	const auto bump = machine.address_of("bump");
+	const auto get_counter = machine.address_of("get_counter");
+	REQUIRE(bump != 0x0);
+	REQUIRE(get_counter != 0x0);
+
+	const size_t baseline = count_vcpu_mappings();
+	static constexpr size_t SMP_CPUS = 2;
+
+	{
+		tinykvm::Machine fork { machine, lazy_options() };
+		fork.timed_vmcall(get_counter, 4.0f); /* main vCPU: +1 mapping */
+
+		const uint64_t stack = fork.mmap_allocate((SMP_CPUS + 1) * 0x4000);
+		fork.smp().timed_smpcall(SMP_CPUS, stack, 0x4000, bump, 4.0f);
+		fork.smp_wait();
+		REQUIRE(fork.smp_active_count() == 0);
+		REQUIRE(count_vcpu_mappings() == baseline + 1 + SMP_CPUS);
+
+		/* A reset recycles the same vCPUs in place -- "never unmap on park"
+		   (Term 3 in the design doc: unmapping on park would cost an O(N)
+		   invalidate fan-out plus a TLB shootdown for nothing, since the next
+		   tenant just remaps it). Every mapping this fork has ever created
+		   survives the reset. */
+		fork.reset_to(machine, lazy_options());
+		REQUIRE(count_vcpu_mappings() == baseline + 1 + SMP_CPUS);
+
+		fork.timed_vmcall(get_counter, 4.0f);
+		REQUIRE(fork.return_value() == 0); /* fresh master state: no bumps yet */
+		REQUIRE(count_vcpu_mappings() == baseline + 1 + SMP_CPUS);
+	}
+	/* Only real teardown (~Machine) releases every per-vCPU mapping the fork
+	   ever created -- main and every SMP vCPU alike. */
+	REQUIRE(count_vcpu_mappings() == baseline);
 }


### PR DESCRIPTION
## Summary


- **fast-agent#18 — cross-process master path.** `Cross-process master path: a worker builds and runs its own fork` (`tests/unit/fork.cpp`) and `ARM64 cross-process master path: a worker builds and runs its own fork` (`tests/unit/arm64_fork.cpp`). Builds+snapshots a master, `fork()`s a worker process, and constructs + runs a TinyKVM fork of the master *inside the child* — reporting status back over a pipe so the parent can assert success. This is the regression guard for the ARM64 fd-ownership bug just fixed by #114: KVM binds a VM to its creating process's `mm`, so the fork constructor and `reset_to()` must never issue a vCPU ioctl against the master's fd from another process. Also exercises the process-per-vm worker recycle path (`reset_to()`) cross-process, and checks the master is unharmed afterward. Verified live on this aarch64/16K-page host.

- **fast-agent#19 — SMP fork × lazy kvm_run.** `SMP fork lazily maps its main vCPU and eagerly maps the SMP vCPUs it brings up` and `SMP fork teardown releases every per-vCPU kvm_run mapping` (`tests/unit/lazy_kvm_run.cpp`). A master with real SMP (`Machine::smp()`, not the cooperative `MultiThreading` green threads) is forked with `lazy_vcpu_mmap` enabled. Asserts: (a) the fork's main vCPU kvm_run mapping still only materializes on first use, unaffected by the master's own SMP history; (b) every SMP vCPU the fork brings up actually executes and is counted, one mapping per vCPU that has ever run; (c) `reset_to()` keeps every per-vCPU mapping alive ("never unmap on park" — Term 3 in `docs/design/create-fork-vm-pooling.md`), and only real teardown (`~Machine`) releases them. SMP is AMD64-only in this tree (`Machine::smp()` throws "not implemented" on ARM64), so there is no ARM64 counterpart.

- **fast-agent#20 — set_tls_base fork-path sregs read-back, master tid != 1.** `Fork inherits FS base from master's non-default current thread` (`fork.cpp`) and `ARM64 fork inherits tpidr_el0 from master's non-default current thread` (`arm64_fork.cpp`). Constructs a master whose *current* `MultiThreading` thread id is 7 (not the default 1) before it is snapshotted, via the public `MultiThreading` API (`tinykvm/linux/threads.hpp`) rather than a fragile guest-side `clone()` dance. On x86 the fork's FS base is read back via the C++ accessor (correct pre-run) and again via a raw `KVM_GET_SREGS` ioctl after running the fork once, confirming it actually landed on the real hardware register. On ARM64, `MultiThreading::reset_to` is the *only* place a fork's `tpidr_el0` is ever set (unlike x86, ARM64's `setup_cow_mode()` never touches TPIDR_EL0), so this is a non-redundant regression guard there, read back via `Machine::tpidr_el0()`.

Also: `arm64_elf.cpp` had a missing `<unistd.h>` (GCC 16 header hygiene, `access()`/`R_OK`) that silently blocked the whole binary from building on this host — fixed, since it was masking whatever the suite underneath does or does not catch.

## Test plan

- [x] `ctest` green on this aarch64/16K-page host, except one **pre-existing, unrelated** failure now newly visible (`ARM64 runs a dynamic Python guest` — `writable_page_at: l2 entry not writable`), previously hidden entirely by the arm64_elf.cpp build failure above. Not touched by this PR; flagging for a maintainer to triage separately.
- [x] New ARM64 tests (`test_arm64_fork`) pass on real `/dev/kvm`.
- [x] AMD64-only additions (`fork.cpp`, `lazy_kvm_run.cpp`) checked with a real x86_64 GCC 13 toolchain under qemu-user emulation (no x86 KVM host available here): clean `-Wall -Wextra` compile both via `-fsyntax-only` and as real object files, and the full 26-file AMD64 tinykvm library builds cleanly against the same headers. Linking and running still need a real x86_64 KVM host — please confirm in CI/on hardware.

Fixes varnish/fast-agent#18, #19, #20 once the parent pointer is bumped (cross-repo closes don't auto-fire).

🤖 Generated with [Claude Code](https://claude.com/claude-code)