### PR TITLE
perf: defer the per-fork execution timer and the x86 vCPU bring-up

### DIFF
--- a/lib/tinykvm/arm64/vcpu.cpp
+++ b/lib/tinykvm/arm64/vcpu.cpp
@@ -103,10 +103,6 @@ void vCPU::init(int kvm_vcpu_id, int guest_cpu_index, Machine& machine, const Ma
 			Machine::machine_exception("KVM_ARM_VCPU_INIT failed", errno);
 		}
 	}
-	if (this->timer_id == nullptr) {
-		this->timer_id = Machine::create_vcpu_timer();
-		this->timer_tid = gettid();
-	}
 	/* Defer the kvm_run mapping to the first run when lazy_vcpu_mmap is set:
 	   ensure_kvm_run() (run_once) creates it on demand. A fork that never runs
 	   then never pays the mapping's host VMA -- the property vm_group_vma_flat
@@ -132,9 +128,9 @@ void vCPU::init_from_seat(VmGroupSeat& seat, Machine& machine,
 	this->guest_cpu_index = 0;
 	this->last_fault_address = 0;
 	this->m_machine = &machine;
-	/* Armed before anything is taken: from here on fd, kvm_run and the timer
-	   are the seat's, and ~vCPU must not close, unmap or delete any of them
-	   however this function exits. */
+	/* Armed before anything is taken: from here on fd and kvm_run are the
+	   seat's, and ~vCPU must not close or unmap either however this function
+	   exits. */
 	this->m_seat_borrowed = true;
 
 	/* The seat's vCPU is created when the group materializes the seat and is
@@ -145,22 +141,11 @@ void vCPU::init_from_seat(VmGroupSeat& seat, Machine& machine,
 	}
 	this->fd = seat.vcpu_fd;
 
-	/* Rebind the seat's execution timer to this thread when a different thread
-	   created it: the timer is thread-bound (SIGEV_THREAD_ID) but the seat is
-	   handed to whichever thread takes it next. Same reasoning, and the same
-	   cost, as the AMD64 path and Machine::migrate_to_this_thread(). */
-	const pid_t this_tid = gettid();
-	if (seat.timer_id != nullptr && seat.owner_tid != this_tid) {
-		timer_delete((timer_t)seat.timer_id);
-		seat.timer_id = nullptr;
-		seat.owner_tid = 0;
-	}
-	if (seat.timer_id == nullptr) {
-		seat.timer_id = Machine::create_vcpu_timer();
-		seat.owner_tid = this_tid;
-	}
-	this->timer_id = seat.timer_id;
-	this->timer_tid = seat.owner_tid;
+	/* No timer is adopted: the execution timer belongs to whichever thread
+	   runs this tenant, not to the seat (Machine::this_thread_vcpu_timer()).
+	   A seat used to carry one, and because the timer is thread-bound
+	   (SIGEV_THREAD_ID) every hand-off to a different thread paid a
+	   timer_delete() plus a timer_create() to rebind it. */
 
 	/* kvm_run belongs to the seat and outlives every tenant (torn down only
 	   when the group retires the seat). Adopt the seat's existing mapping if a
@@ -208,21 +193,18 @@ void vCPU::init_from_seat(VmGroupSeat& seat, Machine& machine,
 
 void vCPU::detach_to_seat(VmGroupSeat& seat) noexcept
 {
-	/* Hand fd, kvm_run and timer back to the seat without closing or unmapping
+	/* Hand fd and kvm_run back to the seat without closing or unmapping
 	   anything: a struct kvm consumes vCPU capacity permanently, so closing the
-	   fd would burn the seat rather than free it. The next tenant re-adopts all
-	   three in init_from_seat(). No shadow-register teardown as on AMD64 -- ARM
-	   has no lazy mapping, so there is nothing owned to delete. */
+	   fd would burn the seat rather than free it. The next tenant re-adopts
+	   both in init_from_seat(). No timer, because a seat has none; and no
+	   shadow-register teardown as on AMD64 -- ARM has no lazy mapping, so
+	   there is nothing owned to delete. */
 	if (this->fd >= 0) {
 		seat.vcpu_fd   = this->fd;
 		seat.kvm_run   = this->kvm_run;
-		seat.timer_id  = this->timer_id;
-		seat.owner_tid = this->timer_tid;
 	}
 	this->fd = -1;
 	this->kvm_run = nullptr;
-	this->timer_id = nullptr;
-	this->timer_tid = 0;
 	this->m_regs_cached = false;
 	this->m_regs_dirty = false;
 	this->m_seat_borrowed = false;
@@ -274,11 +256,7 @@ void vCPU::deinit()
 		munmap(kvm_run, vcpu_mmap_size);
 		kvm_run = nullptr;
 	}
-	if (this->timer_id != nullptr) {
-		timer_delete((timer_t)this->timer_id);
-		this->timer_id = nullptr;
-		this->timer_tid = 0;
-	}
+	/* No timer to delete: it is the running thread's, not the vCPU's. */
 }
 
 vCPU::~vCPU()

--- a/lib/tinykvm/arm64/vcpu_run.cpp
+++ b/lib/tinykvm/arm64/vcpu_run.cpp
@@ -95,26 +95,25 @@ void vCPU::run(uint32_t ticks)
 	   tables. */
 	this->flush_pending_guest_tlb();
 
+	/* The execution timer belongs to this thread, and is shared by every vCPU
+	   that runs on it, so a run() nested inside another -- a syscall handler
+	   that runs a second machine, or the deferred TLB flush above -- must put
+	   the outer run's deadline back on its way out instead of disarming it. See
+	   the AMD64 vCPU::run() and VcpuTimerArming. */
+	const VcpuTimerArming outer_arming =
+		Machine::this_thread_vcpu_timer_arming();
+	const bool outer_triggered = timer_was_triggered;
+	const uint32_t outer_ticks = this->timer_ticks;
+
 	timer_was_triggered = false;
 	this->timer_ticks = ticks;
 	if (timer_ticks != 0) {
-		const struct itimerspec its {
-			.it_interval = {
-				.tv_sec = 0, .tv_nsec = 20'000'000L
-			},
-			.it_value = {
-				.tv_sec = ticks / 1000,
-				.tv_nsec = (ticks % 1000) * 1000000L
-			}
-		};
-		/* The running thread's timer, not this vCPU's -- only one vCPU can be
-		   inside run() on a thread at a time, and the timer must be bound to
-		   the thread whose KVM_RUN it has to interrupt (SIGEV_THREAD_ID).
-		   Created on first use, here. */
-		void* const timer_id = Machine::this_thread_vcpu_timer();
-		timer_settime((timer_t)timer_id, 0, &its, nullptr);
+		/* The running thread's timer, not this vCPU's: it must be bound to the
+		   thread whose KVM_RUN it has to interrupt (SIGEV_THREAD_ID). Created
+		   on first use, here. */
+		Machine::arm_this_thread_vcpu_timer(ticks);
 		if constexpr (VERBOSE_TIMER) {
-			printf("Timer %p enabled\n", timer_id);
+			printf("Timer enabled for %u ms\n", ticks);
 		}
 	}
 
@@ -123,10 +122,28 @@ void vCPU::run(uint32_t ticks)
 		while(run_once());
 	} catch (...) {
 		disable_timer();
+		this->restore_outer_timer(outer_arming, outer_triggered, outer_ticks);
 		throw;
 	}
 
 	disable_timer();
+	this->restore_outer_timer(outer_arming, outer_triggered, outer_ticks);
+}
+
+void vCPU::restore_outer_timer(const VcpuTimerArming& outer_arming,
+	bool outer_triggered, uint32_t outer_ticks)
+{
+	if (LIKELY(!outer_arming.armed))
+		return;
+	timer_was_triggered = outer_triggered;
+	/* Zero unless the outer run is on this same vCPU -- which for ARM64 is the
+	   deferred TLB flush above, though that one runs before timer_ticks is set
+	   and so has nothing of its own to lose. */
+	this->timer_ticks = outer_ticks;
+	/* Last: a restored deadline that has already passed is delivered during this
+	   call, and the handler's write to timer_was_triggered must not be the one
+	   overwritten above. */
+	Machine::restore_this_thread_vcpu_timer(outer_arming);
 }
 
 void vCPU::disable_timer()
@@ -134,11 +151,9 @@ void vCPU::disable_timer()
 	timer_was_triggered = false;
 	if (timer_ticks != 0) {
 		this->timer_ticks = 0;
-		struct itimerspec its;
-		__builtin_memset(&its, 0, sizeof(its));
 		/* timer_ticks != 0 means run() armed it, on this thread, in this call
 		   frame -- so this is the very timer that was armed. */
-		timer_settime((timer_t)Machine::this_thread_vcpu_timer(), 0, &its, nullptr);
+		Machine::disarm_this_thread_vcpu_timer();
 	}
 }
 

--- a/lib/tinykvm/arm64/vcpu_run.cpp
+++ b/lib/tinykvm/arm64/vcpu_run.cpp
@@ -107,7 +107,12 @@ void vCPU::run(uint32_t ticks)
 				.tv_nsec = (ticks % 1000) * 1000000L
 			}
 		};
-		timer_settime((timer_t)this->timer_id, 0, &its, nullptr);
+		/* The running thread's timer, not this vCPU's -- only one vCPU can be
+		   inside run() on a thread at a time, and the timer must be bound to
+		   the thread whose KVM_RUN it has to interrupt (SIGEV_THREAD_ID).
+		   Created on first use, here. */
+		void* const timer_id = Machine::this_thread_vcpu_timer();
+		timer_settime((timer_t)timer_id, 0, &its, nullptr);
 		if constexpr (VERBOSE_TIMER) {
 			printf("Timer %p enabled\n", timer_id);
 		}
@@ -131,7 +136,9 @@ void vCPU::disable_timer()
 		this->timer_ticks = 0;
 		struct itimerspec its;
 		__builtin_memset(&its, 0, sizeof(its));
-		timer_settime((timer_t)this->timer_id, 0, &its, nullptr);
+		/* timer_ticks != 0 means run() armed it, on this thread, in this call
+		   frame -- so this is the very timer that was armed. */
+		timer_settime((timer_t)Machine::this_thread_vcpu_timer(), 0, &its, nullptr);
 	}
 }
 
@@ -303,9 +310,11 @@ unsigned vCPU::exception_extra_offset(uint8_t)
 
 void Machine::migrate_to_this_thread()
 {
-	timer_delete((timer_t)vcpu.timer_id);
-	vcpu.timer_id = create_vcpu_timer();
-	vcpu.timer_tid = gettid();
+	/* Nothing left to do. Its whole job was re-creating the vCPU's
+	   thread-bound execution timer on the new thread; the timer now belongs to
+	   the thread that runs the vCPU (Machine::this_thread_vcpu_timer()) and is
+	   therefore always already bound correctly. Kept as a no-op because
+	   callers outside this tree wrap every thread hand-off in it. */
 }
 
 } // namespace tinykvm

--- a/lib/tinykvm/common.hpp
+++ b/lib/tinykvm/common.hpp
@@ -30,6 +30,14 @@ static constexpr inline uint64_t PageMask() {
 #define TINYKVM_LAZY_VCPU_MMAP_DEFAULT false
 #endif
 
+/* Default for MachineOptions::lazy_vcpu_bringup. Build with
+   -DTINYKVM_LAZY_VCPU_BRINGUP_DEFAULT=true to defer every fork's vCPU
+   bring-up, which is how the unit test suite is A/B'ed against the eager
+   path. */
+#ifndef TINYKVM_LAZY_VCPU_BRINGUP_DEFAULT
+#define TINYKVM_LAZY_VCPU_BRINGUP_DEFAULT false
+#endif
+
 /* Default for MachineOptions::vm_group. Build with
    -DTINYKVM_VM_GROUP_DEFAULT=true to pool every fork, which is how the
    unit test suite is A/B'ed against the one-VM-per-fork path. */
@@ -207,6 +215,18 @@ namespace tinykvm
 		   constructed in a process that inherited it over fork().
 		   (AMD64 only.) */
 		bool lazy_vcpu_mmap = TINYKVM_LAZY_VCPU_MMAP_DEFAULT;
+		/* When enabled, a forked VM defers the one-time vCPU bring-up KVM
+		   wants before the first KVM_RUN -- KVM_SET_CPUID2, which dominates
+		   it, plus KVM_SET_XCRS and KVM_SET_MSRS -- from construction to that
+		   first run, exactly as lazy_vcpu_mmap defers the kvm_run mapping. A
+		   fork created and recycled without ever running (warm-pool churn)
+		   then pays none of them, and under VM pooling a seat handed straight
+		   back keeps its CPUID owed for the next tenant instead of spending
+		   it. Only forks are affected: a master exists in order to run.
+		   (AMD64 only. The ARM64 analogue, KVM_ARM_VCPU_INIT, is already once
+		   per VM group seat rather than once per fork, and there is no
+		   XCRS/MSRS equivalent, so there is nothing per-fork left to defer.) */
+		bool lazy_vcpu_bringup = TINYKVM_LAZY_VCPU_BRINGUP_DEFAULT;
 		/* Pool this fork into a shared struct kvm with up to vm_group_size
 		   siblings of the same master, instead of creating a VM of its own.
 		   Removes the per-fork KVM_CREATE_VM, and with it both the

--- a/lib/tinykvm/machine.cpp
+++ b/lib/tinykvm/machine.cpp
@@ -13,6 +13,7 @@
 #include <fcntl.h>
 #include <linux/kvm.h>
 #include <sys/ioctl.h>
+#include <time.h> /* timer_delete(), for this_thread_vcpu_timer() */
 extern "C" int close(int);
 //#define KVM_VERBOSE_MEMORY
 
@@ -624,6 +625,34 @@ __attribute__ ((cold))
 void Machine::init()
 {
 	Machine::kvm_fd = kvm_open();
+}
+
+void* Machine::this_thread_vcpu_timer()
+{
+	/* Deleted on thread exit, which is the only moment a timer can be freed
+	   without knowing whether some vCPU is about to run here again. Threads
+	   that run vCPUs are long-lived worker threads, so this is one timer per
+	   worker for the process's life -- the point of the change. */
+	struct ThreadTimer {
+		void* id = nullptr;
+		/* NOT `id != nullptr`. glibc encodes a signal-notified timer_t as the
+		   bare kernel timer id, so the *first* timer a process creates is
+		   literally (timer_t)0 -- indistinguishable from "none" and, treated
+		   as such, re-created on the next call and then leaked. */
+		bool created = false;
+		~ThreadTimer() {
+			if (this->created)
+				timer_delete((timer_t)this->id);
+		}
+	};
+	thread_local ThreadTimer timer;
+	if (UNLIKELY(!timer.created)) {
+		/* Arch-specific only in where it lives; both create the same
+		   SIGEV_THREAD_ID/SIGUSR2 timer bound to the calling thread. */
+		timer.id = Machine::create_vcpu_timer();
+		timer.created = true;
+	}
+	return timer.id;
 }
 
 __attribute__ ((cold))

--- a/lib/tinykvm/machine.cpp
+++ b/lib/tinykvm/machine.cpp
@@ -13,7 +13,7 @@
 #include <fcntl.h>
 #include <linux/kvm.h>
 #include <sys/ioctl.h>
-#include <time.h> /* timer_delete(), for this_thread_vcpu_timer() */
+#include <time.h> /* timer_create/settime/delete, for this_thread_vcpu_timer() */
 extern "C" int close(int);
 //#define KVM_VERBOSE_MEMORY
 
@@ -627,8 +627,7 @@ void Machine::init()
 	Machine::kvm_fd = kvm_open();
 }
 
-void* Machine::this_thread_vcpu_timer()
-{
+namespace {
 	/* Deleted on thread exit, which is the only moment a timer can be freed
 	   without knowing whether some vCPU is about to run here again. Threads
 	   that run vCPUs are long-lived worker threads, so this is one timer per
@@ -640,12 +639,49 @@ void* Machine::this_thread_vcpu_timer()
 		   literally (timer_t)0 -- indistinguishable from "none" and, treated
 		   as such, re-created on the next call and then leaked. */
 		bool created = false;
+		/* The deadline currently armed, so that a nested run() can hand it
+		   back. Kept here rather than in the vCPU because the timer, and
+		   therefore the arming, is the thread's. */
+		uint64_t deadline_ns = 0;
+		bool armed = false;
 		~ThreadTimer() {
 			if (this->created)
 				timer_delete((timer_t)this->id);
 		}
 	};
-	thread_local ThreadTimer timer;
+	/* Does not create the timer; see Machine::this_thread_vcpu_timer(). */
+	ThreadTimer& this_thread_timer() {
+		thread_local ThreadTimer timer;
+		return timer;
+	}
+	constexpr uint64_t NANOS = 1'000'000'000ULL;
+	/* Interrupt every 20ms after the deadline. This makes sure that we will
+	   eventually exit all blocking calls and at the end exit KVM_RUN to time
+	   out the request. If there is a blocking loop that doesn't exit properly,
+	   the 20ms recurring interruption should not cause too much wasted
+	   CPU-time. */
+	constexpr long RETRY_INTERVAL_NS = 20'000'000L;
+
+	/* Arm the thread's timer at an absolute CLOCK_MONOTONIC deadline. A
+	   deadline in the past is delivered immediately, which is the point: a run
+	   resumed after its budget ran out during a nested run() must time out. */
+	void arm_at(ThreadTimer& timer, uint64_t deadline_ns) {
+		const struct itimerspec its {
+			.it_interval = { .tv_sec = 0, .tv_nsec = RETRY_INTERVAL_NS },
+			.it_value = {
+				.tv_sec  = (time_t)(deadline_ns / NANOS),
+				.tv_nsec = (long)(deadline_ns % NANOS)
+			}
+		};
+		timer_settime((timer_t)timer.id, TIMER_ABSTIME, &its, nullptr);
+		timer.deadline_ns = deadline_ns;
+		timer.armed = true;
+	}
+}
+
+void* Machine::this_thread_vcpu_timer()
+{
+	ThreadTimer& timer = this_thread_timer();
 	if (UNLIKELY(!timer.created)) {
 		/* Arch-specific only in where it lives; both create the same
 		   SIGEV_THREAD_ID/SIGUSR2 timer bound to the calling thread. */
@@ -653,6 +689,46 @@ void* Machine::this_thread_vcpu_timer()
 		timer.created = true;
 	}
 	return timer.id;
+}
+
+VcpuTimerArming Machine::this_thread_vcpu_timer_arming()
+{
+	const ThreadTimer& timer = this_thread_timer();
+	return { timer.deadline_ns, timer.armed };
+}
+
+void Machine::arm_this_thread_vcpu_timer(uint32_t ticks)
+{
+	/* Creates the timer if this thread has never armed one. */
+	Machine::this_thread_vcpu_timer();
+
+	struct timespec now;
+	clock_gettime(CLOCK_MONOTONIC, &now);
+	const uint64_t now_ns = (uint64_t)now.tv_sec * NANOS + (uint64_t)now.tv_nsec;
+	arm_at(this_thread_timer(), now_ns + (uint64_t)ticks * 1'000'000ULL);
+}
+
+void Machine::disarm_this_thread_vcpu_timer()
+{
+	ThreadTimer& timer = this_thread_timer();
+	/* Only reachable after this thread armed something, which created it. */
+	if (UNLIKELY(!timer.created))
+		return;
+	struct itimerspec its;
+	__builtin_memset(&its, 0, sizeof(its));
+	timer_settime((timer_t)timer.id, 0, &its, nullptr);
+	timer.deadline_ns = 0;
+	timer.armed = false;
+}
+
+void Machine::restore_this_thread_vcpu_timer(const VcpuTimerArming& arming)
+{
+	if (!arming.armed) {
+		Machine::disarm_this_thread_vcpu_timer();
+		return;
+	}
+	Machine::this_thread_vcpu_timer();
+	arm_at(this_thread_timer(), arming.deadline_ns);
 }
 
 __attribute__ ((cold))

--- a/lib/tinykvm/machine.hpp
+++ b/lib/tinykvm/machine.hpp
@@ -575,11 +575,24 @@ private:
 
 	   Nothing is lost by the sharing, because the timeout signal was already
 	   per-thread and not per-vCPU: the SIGUSR2 handler sets a thread_local
-	   timer_was_triggered, and vCPU::run() clears it on entry. Only one vCPU
-	   can be inside run() on a thread at a time -- a vCPU is affine to the
-	   thread running it -- and a nested run() on the same thread already
-	   clobbered that flag before this change. */
+	   timer_was_triggered, and vCPU::run() clears it on entry.
+
+	   One vCPU per thread is the common case but not the only one: a syscall
+	   handler may run a *second* machine, nesting one run() inside another on
+	   the same thread. Because the timer is shared, the inner run() must put
+	   the outer's deadline back when it leaves -- see VcpuTimerArming and
+	   vCPU::run(). */
 	static void* this_thread_vcpu_timer();
+	/* What is armed on this thread right now, for an inner run() to restore.
+	   Deliberately does not create the timer: a thread that never arms one
+	   must not acquire one just by asking. */
+	static VcpuTimerArming this_thread_vcpu_timer_arming();
+	/* Arm the calling thread's timer `ticks` milliseconds from now. */
+	static void arm_this_thread_vcpu_timer(uint32_t ticks);
+	/* Disarm it, and record that nothing is armed. */
+	static void disarm_this_thread_vcpu_timer();
+	/* Re-arm a deadline taken from this_thread_vcpu_timer_arming(). */
+	static void restore_this_thread_vcpu_timer(const VcpuTimerArming&);
 	friend struct vCPU;
 	friend struct VmGroup;
 	friend struct VmGroupSet;

--- a/lib/tinykvm/machine.hpp
+++ b/lib/tinykvm/machine.hpp
@@ -404,7 +404,14 @@ struct Machine
 	}
 
 	/* Migrates the VM to the current thread. Allows creating in
-	   one thread, and using it in another. */
+	   one thread, and using it in another.
+
+	   Now a no-op, kept because callers outside this tree call it around every
+	   thread hand-off: the only thing it ever did was re-create the vCPU's
+	   thread-bound execution timer, and the timer is no longer the vCPU's --
+	   it belongs to the thread that runs it. See
+	   Machine::this_thread_vcpu_timer(). Calling it is still correct and still
+	   documents the hand-off; it just costs nothing now. */
 	void migrate_to_this_thread();
 	/* Store non-memory VM state to the already existing cold
 	   start state area in memory. Any failure will throw an
@@ -552,6 +559,27 @@ private:
 	static int create_kvm_vm();
 	static int kvm_fd;
 	static void* create_vcpu_timer();
+	/* The calling thread's execution timer, created on first use and deleted
+	   when the thread exits. Every vCPU that runs on this thread arms and
+	   disarms this one timer.
+
+	   It used to be one timer per vCPU, created eagerly during construction --
+	   so a pool of N warm forks cost N timer_create()s and N kernel k_itimers
+	   that nothing was using, and a VM group seat handed to a different thread
+	   had to timer_delete() and re-create its own (the timer is thread-bound
+	   through SIGEV_THREAD_ID, and one bound to a foreign thread both fails to
+	   interrupt this thread's KVM_RUN and times out whichever innocent sibling
+	   is running over there). Per-thread ownership makes that whole rebind
+	   question disappear: the timer is created by, and bound to, the thread
+	   that uses it, always.
+
+	   Nothing is lost by the sharing, because the timeout signal was already
+	   per-thread and not per-vCPU: the SIGUSR2 handler sets a thread_local
+	   timer_was_triggered, and vCPU::run() clears it on entry. Only one vCPU
+	   can be inside run() on a thread at a time -- a vCPU is affine to the
+	   thread running it -- and a nested run() on the same thread already
+	   clobbered that flag before this change. */
+	static void* this_thread_vcpu_timer();
 	friend struct vCPU;
 	friend struct VmGroup;
 	friend struct VmGroupSet;

--- a/lib/tinykvm/vcpu.cpp
+++ b/lib/tinykvm/vcpu.cpp
@@ -161,10 +161,11 @@ void vCPU::init(int kvm_vcpu_id, int guest_cpu_index, Machine& machine, const Ma
 			Machine::machine_exception("Failed to KVM_CREATE_VCPU");
 		}
 	}
-	if (this->timer_id == nullptr) {
-		this->timer_id = Machine::create_vcpu_timer();
-		this->timer_tid = gettid();
-	}
+	/* A fork may defer its one-time bring-up (CPUID2, XCRS, MSRS) to its first
+	   run, so a warm fork that is never run pays none of it. Masters are
+	   always brought up eagerly: they exist in order to run. */
+	const bool defer_bringup = options.lazy_vcpu_bringup && machine.is_forked();
+
 	if (!this->m_initialized) {
 		this->m_initialized = true;
 
@@ -183,9 +184,14 @@ void vCPU::init(int kvm_vcpu_id, int guest_cpu_index, Machine& machine, const Ma
 		}
 
 		/* Assign CPUID features to guest. I don't believe the guest
-		   can change of this, so we will only set it once. */
-		if (ioctl(this->fd, KVM_SET_CPUID2, &kvm_cpuid) < 0) {
-			Machine::machine_exception("KVM_SET_CPUID2 failed");
+		   can change of this, so we will only set it once -- which is why it
+		   is owed from inside this branch and nowhere else. */
+		this->m_pending_cpuid = true;
+		if (!defer_bringup) {
+			this->m_pending_cpuid = false;
+			if (ioctl(this->fd, KVM_SET_CPUID2, &kvm_cpuid) < 0) {
+				Machine::machine_exception("KVM_SET_CPUID2 failed");
+			}
 		}
 	}
 
@@ -233,7 +239,11 @@ void vCPU::init(int kvm_vcpu_id, int guest_cpu_index, Machine& machine, const Ma
 		this->set_special_registers(master_sregs);
 	}
 
-	this->init_extended_state(machine);
+	if (defer_bringup) {
+		this->m_pending_bringup = true;
+	} else {
+		this->init_extended_state(machine);
+	}
 }
 
 void vCPU::init_from_seat(VmGroupSeat& seat, Machine& machine,
@@ -243,9 +253,9 @@ void vCPU::init_from_seat(VmGroupSeat& seat, Machine& machine,
 	this->guest_cpu_index = 0;
 	this->last_fault_address = 0;
 	this->m_machine = &machine;
-	/* Armed before anything is taken: from here on fd, kvm_run and the timer
-	   are the seat's, and ~vCPU must not close, unmap or delete any of them
-	   however this function exits. */
+	/* Armed before anything is taken: from here on fd and kvm_run are the
+	   seat's, and ~vCPU must not close or unmap either however this function
+	   exits. */
 	this->m_seat_borrowed = true;
 
 	/* The seat's vCPU was created when the group materialized the seat, and is
@@ -259,29 +269,10 @@ void vCPU::init_from_seat(VmGroupSeat& seat, Machine& machine,
 	}
 	this->fd = seat.vcpu_fd;
 
-	/* The seat's timer is bound to the thread that created it (SIGEV_THREAD_ID
-	   with sigev_tid), but the seat itself is not thread-bound: any thread may
-	   be handed it next. Adopting a foreign-thread timer would break two ways
-	   at once - this tenant's execution timeout would never interrupt its
-	   KVM_RUN (an infinite guest loop would hang forever), and the 20ms
-	   re-arm interval would keep firing at the *original* thread, setting its
-	   thread_local timer_was_triggered and timing out whichever innocent
-	   sibling happens to be running there. So rebind on adoption, paying
-	   exactly what Machine::migrate_to_this_thread() pays. */
-	const pid_t this_tid = gettid();
-	if (seat.timer_id != nullptr && seat.owner_tid != this_tid) {
-		timer_delete((timer_t)seat.timer_id);
-		/* Cleared before the create, so a throw cannot leave the seat (and
-		   thus the group destructor) holding a deleted timer. */
-		seat.timer_id = nullptr;
-		seat.owner_tid = 0;
-	}
-	if (seat.timer_id == nullptr) {
-		seat.timer_id = Machine::create_vcpu_timer();
-		seat.owner_tid = this_tid;
-	}
-	this->timer_id = seat.timer_id;
-	this->timer_tid = seat.owner_tid;
+	/* No timer is adopted: the execution timer belongs to whichever thread
+	   runs this tenant, not to the seat (Machine::this_thread_vcpu_timer()).
+	   A seat used to carry one, which meant every hand-off to a different
+	   thread paid a timer_delete() plus a timer_create() to rebind it. */
 
 	this->m_initialized = true;
 	if (seat.kvm_run != nullptr) {
@@ -296,15 +287,70 @@ void vCPU::init_from_seat(VmGroupSeat& seat, Machine& machine,
 		seat.kvm_run = this->kvm_run;
 	}
 
-	if (!seat.vcpu_initialized) {
-		seat.vcpu_initialized = true;
-		/* Assign CPUID features to guest. Once per seat: KVM rejects a
-		   changed CPUID after the vCPU has run. */
+	/* Pooled machines are always forks, so they inherit the master's special
+	   registers instead of building their own (see init()). What is left is
+	   the bring-up KVM wants before the first KVM_RUN -- deferred to exactly
+	   that point under lazy_vcpu_bringup, so a seat taken and handed straight
+	   back never pays it. CPUID2 is owed once per *seat*, not per tenant. */
+	this->m_pending_cpuid = !seat.vcpu_initialized;
+	this->m_pending_bringup = true;
+	if (!options.lazy_vcpu_bringup) {
+		this->complete_bringup();
+	}
+}
+
+void vCPU::detach_to_seat(VmGroupSeat& seat) noexcept
+{
+	if (this->fd >= 0) {
+		seat.vcpu_fd  = this->fd;
+		seat.kvm_run  = this->kvm_run;
+	}
+	this->fd = -1;
+	this->kvm_run = nullptr;
+	this->m_regs = nullptr;
+	this->m_sregs = nullptr;
+	delete (ShadowRegisters *)this->m_shadow_regs;
+	this->m_shadow_regs = nullptr;
+	this->m_shadow_dirty_regs = 0;
+	this->m_initialized = false;
+	this->m_seat_borrowed = false;
+	/* Not carried to the seat: whether KVM_SET_CPUID2 has been issued on this
+	   fd is seat.vcpu_initialized's business, and the rest of the bring-up is
+	   re-issued per tenant anyway. */
+	this->m_pending_bringup = false;
+	this->m_pending_cpuid = false;
+}
+
+/* The one-time bring-up KVM wants before this vCPU's first KVM_RUN. Called
+   from construction as before, or -- under lazy_vcpu_bringup, and for forks
+   only -- from the run path, so that a warm fork created and recycled without
+   ever running pays none of it. KVM_SET_CPUID2 is the expensive member of the
+   set; the other two are here because they belong to the same "ready to run"
+   step and are just as pointless on a fork that never runs.
+
+   The split between the two flags mirrors what construction did eagerly:
+   CPUID2 exactly once per vCPU fd (KVM rejects a changed CPUID after the vCPU
+   has run, and a group seat's fd outlives its tenants), XCRS/MSRS re-issued
+   for every tenant. Order matters: XCR0 is validated against the guest CPUID,
+   so CPUID2 goes first. */
+void vCPU::complete_bringup()
+{
+	this->m_pending_bringup = false;
+	auto* seat = this->machine().m_seat;
+
+	if (this->m_pending_cpuid) {
+		this->m_pending_cpuid = false;
+		if (seat != nullptr) {
+			/* Claimed here rather than at construction, so a seat taken and
+			   handed back unrun leaves it for its next tenant. */
+			seat->vcpu_initialized = true;
+		}
 		if (ioctl(this->fd, KVM_SET_CPUID2, &kvm_cpuid) < 0) {
 			Machine::machine_exception("KVM_SET_CPUID2 failed");
 		}
-	} else {
-		/* The previous tenant may have halted. Parity with smp_init(). */
+	} else if (seat != nullptr) {
+		/* A seat whose CPUID is already set has had a previous tenant, and
+		   that tenant may have halted. Parity with smp_init(). */
 		const kvm_mp_state state {
 			.mp_state = KVM_MP_STATE_RUNNABLE
 		};
@@ -313,34 +359,7 @@ void vCPU::init_from_seat(VmGroupSeat& seat, Machine& machine,
 		}
 	}
 
-	/* Pooled machines are always forks, so they inherit the master's special
-	   registers instead of building their own (see init()). */
-	this->init_extended_state(machine);
-}
-
-void vCPU::detach_to_seat(VmGroupSeat& seat) noexcept
-{
-	if (this->fd >= 0) {
-		seat.vcpu_fd  = this->fd;
-		seat.kvm_run  = this->kvm_run;
-		/* The live timer, and the thread it is actually bound to - which is
-		   not necessarily this thread: Machine::migrate_to_this_thread() may
-		   have rebound it elsewhere, and destruction may happen on a third
-		   thread entirely. The next tenant compares against this. */
-		seat.timer_id  = this->timer_id;
-		seat.owner_tid = this->timer_tid;
-	}
-	this->fd = -1;
-	this->kvm_run = nullptr;
-	this->timer_id = nullptr;
-	this->timer_tid = 0;
-	this->m_regs = nullptr;
-	this->m_sregs = nullptr;
-	delete (ShadowRegisters *)this->m_shadow_regs;
-	this->m_shadow_regs = nullptr;
-	this->m_shadow_dirty_regs = 0;
-	this->m_initialized = false;
-	this->m_seat_borrowed = false;
+	this->init_extended_state(this->machine());
 }
 
 void vCPU::init_extended_state(Machine& machine)
@@ -410,8 +429,6 @@ void vCPU::smp_init(int id, Machine& machine)
 	if (UNLIKELY(this->fd < 0)) {
 		Machine::machine_exception("Failed to KVM_CREATE_VCPU");
 	}
-	this->timer_id = Machine::create_vcpu_timer();
-	this->timer_tid = gettid();
 
 	/* SMP vCPUs are only ever created in order to run, and so they are
 	   always mapped eagerly. */
@@ -484,12 +501,7 @@ void vCPU::deinit()
 	delete (ShadowRegisters *)this->m_shadow_regs;
 	this->m_shadow_regs = nullptr;
 	this->m_shadow_dirty_regs = 0;
-
-	if (this->timer_id != nullptr) {
-		timer_delete((timer_t)this->timer_id);
-		this->timer_id = nullptr;
-		this->timer_tid = 0;
-	}
+	/* No timer to delete: it is the running thread's, not the vCPU's. */
 	this->m_initialized = false;
 }
 

--- a/lib/tinykvm/vcpu.hpp
+++ b/lib/tinykvm/vcpu.hpp
@@ -9,6 +9,18 @@ namespace tinykvm
 	struct Machine;
 	struct VmGroupSeat;
 
+	/* An armed execution deadline on a thread. Absolute (the timer runs on
+	   CLOCK_MONOTONIC) rather than a remaining duration, so that a run whose
+	   deadline is saved and restored across a nested run() keeps counting down
+	   through it -- the budget is the guest's wall-clock allowance, and it
+	   behaved this way when every vCPU still owned a timer of its own. A
+	   restored deadline that has already passed fires immediately, which is
+	   what a blown budget should do. See Machine::this_thread_vcpu_timer(). */
+	struct VcpuTimerArming {
+		uint64_t deadline_ns = 0; /* CLOCK_MONOTONIC; only if armed */
+		bool     armed = false;
+	};
+
 	struct vCPU
 	{
 		void init(int kvm_vcpu_id, int guest_cpu_index, Machine&, const MachineOptions&);
@@ -56,6 +68,17 @@ namespace tinykvm
 		long run_once();
 		void stop() { stopped = true; }
 		void disable_timer();
+		/* Put back the timer state an outer run() on this thread had, if this
+		   run was nested inside one: the armed deadline, the pending-timeout
+		   flag, and timer_ticks. The last matters when the nesting is on the
+		   *same* vCPU (Machine::ipre_remote_resume_now() runs one from inside a
+		   syscall handler): timer_ticks is the field run_once() classifies a
+		   timeout by and disable_timer() disarms on, so an inner run that
+		   zeroed it would leave the outer unable to recognise its own timeout
+		   and unable to disarm afterwards. Both arches implement it; run()
+		   calls it on every exit path. */
+		void restore_outer_timer(const VcpuTimerArming&, bool outer_triggered,
+			uint32_t outer_ticks);
 		std::string_view io_data() const;
 
 		bool is_usermode() const;

--- a/lib/tinykvm/vcpu.hpp
+++ b/lib/tinykvm/vcpu.hpp
@@ -20,20 +20,20 @@ namespace tinykvm
 		   Both arches implement this; the per-seat one-time bring-up differs
 		   (KVM_SET_CPUID2 on AMD64, KVM_ARM_VCPU_INIT on ARM64). */
 		void init_from_seat(VmGroupSeat&, Machine&, const MachineOptions&);
-		/* The anti-deinit. Hands fd, kvm_run and timer back to the seat
-		   without closing or unmapping anything: a struct kvm's vCPU capacity
-		   is consumed permanently by every vCPU ever created in it, so
-		   closing the fd would burn the seat instead of freeing it. */
+		/* The anti-deinit. Hands fd and kvm_run back to the seat without
+		   closing or unmapping anything: a struct kvm's vCPU capacity is
+		   consumed permanently by every vCPU ever created in it, so closing
+		   the fd would burn the seat instead of freeing it. */
 		void detach_to_seat(VmGroupSeat&) noexcept;
-		/* Releases everything this vCPU still owns: the KVM_CREATE_VCPU fd, the
-		   POSIX execution timer, the kvm_run mapping and (AMD64) the shadow
-		   registers of a vCPU that never became mapped.
+		/* Releases everything this vCPU still owns: the KVM_CREATE_VCPU fd,
+		   the kvm_run mapping and (AMD64) the shadow registers of a vCPU that
+		   never became mapped.
 
 		   It exists because deinit() is only reached from ~Machine, and
 		   ~Machine is never run for a *constructor* that threw after vCPU
 		   bring-up -- e.g. a fork that ran out of working memory in
-		   setup_cow_mode(), which is downstream of both KVM_CREATE_VCPU and
-		   timer_create(). deinit() clears every field it releases, so on the
+		   setup_cow_mode(), which is downstream of KVM_CREATE_VCPU.
+		   deinit() clears every field it releases, so on the
 		   normal path this destructor finds nothing left to do.
 
 		   A vCPU borrowing a VM group seat (m_seat_borrowed) releases nothing:
@@ -96,22 +96,19 @@ namespace tinykvm
 		bool m_permanent_remote_connected = false;
 		uint8_t current_exception = 0;
 		uint32_t timer_ticks = 0;
-		/* The thread timer_id below is bound to. Every assignment of
-		   timer_id must set this too: it is what lets a VM group seat tell
-		   whether the timer it is handing to its next tenant fires on the
-		   tenant's thread or on a stale one. See Machine::create_vcpu_timer()
-		   (SIGEV_THREAD_ID) and vCPU::detach_to_seat(). */
-		pid_t timer_tid = 0;
-		void* timer_id = nullptr;
-		/* Set while fd, kvm_run and timer_id are on loan from a VM group seat
-		   rather than owned: init_from_seat() borrows all three and
-		   detach_to_seat() hands them back. ~vCPU releases nothing while it is
-		   set — the seat keeps all three for its next tenant, and closing the
-		   fd would burn the group's permanently-consumed vCPU capacity instead
-		   of freeing it. It is not the leak-safety mechanism for a pooled
-		   member (the constructor's seat guard is, and it runs first, before
-		   any member destructor); it is what makes ~vCPU safe if that ever
-		   stops being true. */
+		/* NB: a vCPU owns no execution timer. The timer belongs to the thread
+		   that runs it -- Machine::this_thread_vcpu_timer() -- which is what
+		   keeps a warm pool of N never-run forks from holding N kernel
+		   k_itimers, and what removes the rebind-on-migration question
+		   entirely. */
+		/* Set while fd and kvm_run are on loan from a VM group seat rather than
+		   owned: init_from_seat() borrows both and detach_to_seat() hands them
+		   back. ~vCPU releases nothing while it is set — the seat keeps them
+		   for its next tenant, and closing the fd would burn the group's
+		   permanently-consumed vCPU capacity instead of freeing it. It is not
+		   the leak-safety mechanism for a pooled member (the constructor's seat
+		   guard is, and it runs first, before any member destructor); it is
+		   what makes ~vCPU safe if that ever stops being true. */
 		bool m_seat_borrowed = false;
 		uint64_t last_fault_address = 0;
 		uint64_t remote_return_address = 0;
@@ -133,6 +130,14 @@ namespace tinykvm
 		/* The seat-independent tail of init(): extended control registers
 		   and the SYSCALL/SYSRET MSRs, re-issued for every tenant. */
 		void init_extended_state(Machine&);
+		/* Issue the one-time bring-up KVM wants before the first KVM_RUN, if a
+		   fork deferred it (lazy_vcpu_bringup). Called on the run path only,
+		   next to ensure_kvm_run(); a no-op for anything already brought up. */
+		void ensure_bringup() {
+			if (UNLIKELY(this->m_pending_bringup))
+				this->complete_bringup();
+		}
+		void complete_bringup();
 #else
 		/* ARM has no lazy/shadow register path (registers are read via
 		   KVM_*_ONE_REG on the vCPU fd, not out of kvm_run->s.regs), so a
@@ -165,6 +170,15 @@ namespace tinykvm
 		void* m_shadow_regs = nullptr;
 		uint32_t m_shadow_dirty_regs = 0;
 		bool m_initialized = false;
+		/* This vCPU still owes KVM the bring-up its first KVM_RUN needs. See
+		   complete_bringup(); set only for forks, and only under
+		   MachineOptions::lazy_vcpu_bringup. */
+		bool m_pending_bringup = false;
+		/* ...and specifically the KVM_SET_CPUID2 half of it, which is owed at
+		   most once per vCPU fd (KVM rejects a changed CPUID once the vCPU has
+		   run, and a VM group seat's fd outlives every tenant). Meaningless
+		   unless m_pending_bringup. */
+		bool m_pending_cpuid = false;
 #endif
 
 		uint64_t vcpu_table_addr() const noexcept;

--- a/lib/tinykvm/vcpu_run.cpp
+++ b/lib/tinykvm/vcpu_run.cpp
@@ -44,33 +44,30 @@ bool vCPU::timed_out() const
 
 void vCPU::run(uint32_t ticks)
 {
+	/* The execution timer belongs to this thread, and is shared by every vCPU
+	   that runs on it. A run() nested inside another -- a syscall handler that
+	   runs a second machine -- would therefore disarm, on its way out, the very
+	   deadline protecting the run below it on the stack, leaving that one to
+	   spin in KVM_RUN forever. So save whatever the outer run armed and put it
+	   back before returning. Absolute deadlines (see VcpuTimerArming), so the
+	   outer budget keeps counting down across the inner run.
+
+	   Cheap in the common, un-nested case: a thread-local read here and a
+	   not-armed branch at the end, no extra system call. */
+	const VcpuTimerArming outer_arming =
+		Machine::this_thread_vcpu_timer_arming();
+	const bool outer_triggered = timer_was_triggered;
+	const uint32_t outer_ticks = this->timer_ticks;
+
 	timer_was_triggered = false;
 	this->timer_ticks = ticks;
 	if (timer_ticks != 0) {
-		const struct itimerspec its {
-			/* Interrupt every 20ms after timeout. This makes sure
-			   that we will eventually exit all blocking calls and
-			   at the end exit KVM_RUN to timeout the request. If
-			   there is a blocking loop that doesn't exit properly,
-			   the 20ms recurring interruption should not cause too
-			   much wasted CPU-time. */
-			.it_interval = {
-				.tv_sec = 0, .tv_nsec = 20'000'000L
-			},
-			/* The execution timeout. */
-			.it_value = {
-				.tv_sec = ticks / 1000,
-				.tv_nsec = (ticks % 1000) * 1000000L
-			}
-		};
-		/* The running thread's timer, not this vCPU's -- only one vCPU can be
-		   inside run() on a thread at a time, and the timer must be bound to
-		   the thread whose KVM_RUN it has to interrupt (SIGEV_THREAD_ID).
-		   Created on first use, here. */
-		void* const timer_id = Machine::this_thread_vcpu_timer();
-		timer_settime((timer_t)timer_id, 0, &its, nullptr);
+		/* The running thread's timer, not this vCPU's: it must be bound to the
+		   thread whose KVM_RUN it has to interrupt (SIGEV_THREAD_ID). Created
+		   on first use, here. */
+		Machine::arm_this_thread_vcpu_timer(ticks);
 		if constexpr (VERBOSE_TIMER) {
-			printf("Timer %p enabled\n", timer_id);
+			printf("Timer enabled for %u ms\n", ticks);
 		}
 	}
 
@@ -82,24 +79,42 @@ void vCPU::run(uint32_t ticks)
 		while(run_once());
 	} catch (...) {
 		disable_timer();
+		this->restore_outer_timer(outer_arming, outer_triggered, outer_ticks);
 		throw;
 	}
 
 	disable_timer();
+	this->restore_outer_timer(outer_arming, outer_triggered, outer_ticks);
+}
+void vCPU::restore_outer_timer(const VcpuTimerArming& outer_arming,
+	bool outer_triggered, uint32_t outer_ticks)
+{
+	/* Nothing to restore unless an outer run() on this thread had a deadline
+	   armed, i.e. unless this run was nested inside one. Leaving the flag
+	   cleared otherwise is what an un-nested run has always done -- a late
+	   signal from the 20ms retry interval must not be reported as a timeout by
+	   timed_out() after the run it belonged to has already finished. */
+	if (LIKELY(!outer_arming.armed))
+		return;
+	timer_was_triggered = outer_triggered;
+	/* Zero unless the outer run is on this same vCPU, in which case this is the
+	   timeout it was configured with. */
+	this->timer_ticks = outer_ticks;
+	/* Last: a restored deadline that has already passed is delivered during this
+	   call, and the handler's write to timer_was_triggered must not be the one
+	   overwritten above. */
+	Machine::restore_this_thread_vcpu_timer(outer_arming);
 }
 void vCPU::disable_timer()
 {
 	timer_was_triggered = false;
 	if (timer_ticks != 0) {
 		this->timer_ticks = 0;
-		struct itimerspec its;
-		__builtin_memset(&its, 0, sizeof(its));
 		/* timer_ticks != 0 means run() armed it, on this thread, in this call
 		   frame -- so this is the very timer that was armed. */
-		void* const timer_id = Machine::this_thread_vcpu_timer();
-		timer_settime((timer_t)timer_id, 0, &its, nullptr);
+		Machine::disarm_this_thread_vcpu_timer();
 		if constexpr (VERBOSE_TIMER) {
-			printf("Timer %p disabled\n", timer_id);
+			printf("Timer disabled\n");
 		}
 	}
 }

--- a/lib/tinykvm/vcpu_run.cpp
+++ b/lib/tinykvm/vcpu_run.cpp
@@ -63,7 +63,12 @@ void vCPU::run(uint32_t ticks)
 				.tv_nsec = (ticks % 1000) * 1000000L
 			}
 		};
-		timer_settime(this->timer_id, 0, &its, nullptr);
+		/* The running thread's timer, not this vCPU's -- only one vCPU can be
+		   inside run() on a thread at a time, and the timer must be bound to
+		   the thread whose KVM_RUN it has to interrupt (SIGEV_THREAD_ID).
+		   Created on first use, here. */
+		void* const timer_id = Machine::this_thread_vcpu_timer();
+		timer_settime((timer_t)timer_id, 0, &its, nullptr);
 		if constexpr (VERBOSE_TIMER) {
 			printf("Timer %p enabled\n", timer_id);
 		}
@@ -89,7 +94,10 @@ void vCPU::disable_timer()
 		this->timer_ticks = 0;
 		struct itimerspec its;
 		__builtin_memset(&its, 0, sizeof(its));
-		timer_settime(this->timer_id, 0, &its, nullptr);
+		/* timer_ticks != 0 means run() armed it, on this thread, in this call
+		   frame -- so this is the very timer that was armed. */
+		void* const timer_id = Machine::this_thread_vcpu_timer();
+		timer_settime((timer_t)timer_id, 0, &its, nullptr);
 		if constexpr (VERBOSE_TIMER) {
 			printf("Timer %p disabled\n", timer_id);
 		}
@@ -105,6 +113,10 @@ long vCPU::run_once()
 	   they point at, so that no caller can hold a register reference across
 	   the transition. */
 	this->ensure_kvm_run();
+	/* And a fork may have deferred the bring-up KVM wants before its first
+	   KVM_RUN (CPUID2/XCRS/MSRS). Same reason it is here and not at
+	   construction: a warm fork that is never run must not pay for it. */
+	this->ensure_bringup();
 	{
 		ScopedProfiler<MachineProfiling::VCpuRun> prof(machine().profiling());
 		result = ioctl(this->fd, KVM_RUN, 0);
@@ -130,7 +142,7 @@ long vCPU::run_once()
 		const bool timer_armed = (this->timer_ticks != 0);
 		if (timer_armed && (timer_was_triggered || run_errno == EINTR)) {
 			if constexpr (VERBOSE_TIMER) {
-				printf("Timer %p triggered\n", timer_id);
+				printf("Timer triggered after %u ms\n", this->timer_ticks);
 			}
 			Machine::timeout_exception("Timeout Exception", this->timer_ticks);
 		} else if (run_errno == EINTR) {
@@ -661,17 +673,11 @@ unsigned vCPU::exception_extra_offset(uint8_t intr)
 
 void Machine::migrate_to_this_thread()
 {
-	timer_delete(vcpu.timer_id);
-	vcpu.timer_id = nullptr;
-	vcpu.timer_id = create_vcpu_timer();
-	vcpu.timer_tid = gettid();
-	if (UNLIKELY(this->m_seat != nullptr)) {
-		/* Keep the seat's view of its timer live: the group destructor
-		   timer_delete()s it, and the next tenant compares owner_tid
-		   against its own thread. */
-		m_seat->timer_id  = vcpu.timer_id;
-		m_seat->owner_tid = vcpu.timer_tid;
-	}
+	/* Nothing left to do. Its whole job was re-creating the vCPU's
+	   thread-bound execution timer on the new thread; the timer now belongs to
+	   the thread that runs the vCPU (Machine::this_thread_vcpu_timer()) and is
+	   therefore always already bound correctly. Kept as a no-op because
+	   callers outside this tree wrap every thread hand-off in it. */
 }
 
 } // tinykvm

--- a/lib/tinykvm/vm_group.cpp
+++ b/lib/tinykvm/vm_group.cpp
@@ -509,9 +509,7 @@ VmGroup::~VmGroup()
 	   and an explicit KVM_SET_USER_MEMORY_REGION per slot would only add
 	   ioctls with slots_lock and an expedited SRCU sync each. */
 	for (auto& seat : m_seats) {
-		if (seat->timer_id != nullptr) {
-			timer_delete((timer_t)seat->timer_id);
-		}
+		/* No timer to delete: it is the running thread's, not the seat's. */
 		if (seat->kvm_run != nullptr) {
 			munmap(seat->kvm_run, KvmLimits::get().vcpu_mmap_size);
 		}

--- a/lib/tinykvm/vm_group.hpp
+++ b/lib/tinykvm/vm_group.hpp
@@ -42,12 +42,12 @@ struct VmGroupSeat {
 	   can release what it did get, and is never handed out. */
 	int      vcpu_fd     = -1;
 	void*    kvm_run     = nullptr; /* nullptr while never run (lever C) */
-	void*    timer_id    = nullptr;
-	/* The thread the timer above is bound to (SIGEV_THREAD_ID/sigev_tid). A
-	   seat outlives its tenants and is not thread-bound, so a tenant that
-	   adopts the seat from another thread must rebind the timer: see
-	   vCPU::init_from_seat(). 0 while there is no timer. */
-	pid_t    owner_tid   = 0;
+	/* NB: no timer. A seat used to carry its own POSIX execution timer, and a
+	   seat handed to a different thread had to timer_delete() plus
+	   timer_create() to rebind it (the timer is thread-bound through
+	   SIGEV_THREAD_ID). The timer belongs to the thread now, not to the seat --
+	   Machine::this_thread_vcpu_timer() -- so a seat is genuinely
+	   thread-agnostic and a group of B seats holds no timers at all. */
 	bool     vcpu_initialized = false; /* KVM_SET_CPUID2 already issued */
 	uint64_t arena_gpa   = 0;       /* start of this seat's arena partition */
 	uint64_t arena_size  = 0;       /* usable bytes (stride minus guard band) */

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -38,6 +38,11 @@ add_unit_test(fork_ctor_leak fork_ctor_leak.cpp)
 # explicit rebind logic for.
 add_unit_test(vcpu_timer vcpu_timer.cpp)
 
+# And arch-neutral for the same reason: a run() nested inside another shares the
+# thread's one timer with it, so it has to restore the outer deadline rather than
+# disarm it. Both backends have their own copy of run().
+add_unit_test(nested_timer nested_timer.cpp)
+
 if (TINYKVM_ARCH STREQUAL "AMD64")
 	add_unit_test(basic  basic.cpp)
 	add_unit_test(elf    elf.cpp)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -33,6 +33,11 @@ endfunction()
 # bring-up code that has to obey them.
 add_unit_test(fork_ctor_leak fork_ctor_leak.cpp)
 
+# Also arch-neutral: the execution timer is per-thread on both backends, and
+# the thread-migration case it pins is the one the old per-seat timer needed
+# explicit rebind logic for.
+add_unit_test(vcpu_timer vcpu_timer.cpp)
+
 if (TINYKVM_ARCH STREQUAL "AMD64")
 	add_unit_test(basic  basic.cpp)
 	add_unit_test(elf    elf.cpp)

--- a/tests/unit/nested_timer.cpp
+++ b/tests/unit/nested_timer.cpp
@@ -1,0 +1,159 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <chrono>
+#include <string>
+#include <vector>
+#include <tinykvm/machine.hpp>
+
+/* The execution timer belongs to the thread, so every vCPU that runs on a
+   thread arms and disarms the same one (see Machine::this_thread_vcpu_timer()).
+   A run() nested inside another run() on that thread therefore has to hand the
+   outer run's deadline back when it leaves, instead of disarming it: a syscall
+   handler is free to run a second machine, and the outer guest is still under a
+   deadline while it does.
+
+   Without that, the inner run's disable_timer() disarms the timer that was
+   protecting the outer run, which then sits in KVM_RUN with no timeout armed --
+   an infinite loop in the outer guest hangs the thread for good.
+
+   Arch-neutral: both backends share the timer per thread and both have their
+   own copy of run(). */
+
+extern std::vector<uint8_t> build_and_load(const std::string& code);
+
+static const uint64_t MAX_MEMORY = 32ul << 20; /* 32MB */
+static const std::vector<std::string> env {
+	"LC_TYPE=C", "LC_ALL=C", "USER=root"
+};
+/* Below TINYKVM_MAX_SYSCALLS, and not one Linux uses. */
+static constexpr unsigned SYSCALL_NESTED_RUN = 500;
+
+/* The machine the syscall handler runs, and the flags it reports through.
+   install_syscall_handler() takes a plain function pointer, so this state
+   cannot be captured. */
+static tinykvm::Machine* g_inner = nullptr;
+static bool g_inner_ran = false;
+static std::string g_inner_error;
+
+static void run_inner_machine(tinykvm::vCPU&)
+{
+	g_inner_ran = true;
+	try {
+		/* A generous timeout, so the inner run arms the shared timer far past
+		   the outer run's much shorter deadline. */
+		g_inner->timed_vmcall(g_inner->address_of("quick"), 10.0f);
+	} catch (const std::exception& e) {
+		g_inner_error = e.what();
+	}
+}
+
+TEST_CASE("A nested run leaves the outer run's timeout armed", "[timer]")
+{
+	tinykvm::Machine::init();
+
+	/* Inner: returns immediately, called from the outer machine's handler. */
+	const auto inner_binary = build_and_load(R"M(
+int main() { return 0; }
+extern long quick(void) { return 42; }
+)M");
+	tinykvm::Machine inner { inner_binary, { .max_mem = MAX_MEMORY } };
+	inner.setup_linux({"inner"}, env);
+	inner.run(8.0f);
+	g_inner = &inner;
+
+	/* Outer: runs the inner machine from a syscall, then spins forever. */
+	const auto outer_binary = build_and_load(R"M(
+#include <unistd.h>
+int main() {
+	syscall(500);
+	while (1) { __asm__ volatile(""); }
+	return 0;
+}
+)M");
+	tinykvm::Machine outer { outer_binary, { .max_mem = MAX_MEMORY } };
+	outer.setup_linux({"outer"}, env);
+	tinykvm::Machine::install_syscall_handler(
+		SYSCALL_NESTED_RUN, run_inner_machine);
+
+	bool timed_out = false;
+	std::string other_error;
+	const auto started = std::chrono::steady_clock::now();
+	try {
+		outer.run(0.2f);
+	} catch (const tinykvm::MachineTimeoutException&) {
+		timed_out = true;
+	} catch (const std::exception& e) {
+		other_error = e.what();
+	}
+	const auto elapsed = std::chrono::duration<double>(
+		std::chrono::steady_clock::now() - started).count();
+
+	REQUIRE(g_inner_ran);
+	REQUIRE(g_inner_error.empty());
+	REQUIRE(other_error.empty());
+	/* Hangs forever instead, if the inner run disarmed the outer's timer. */
+	REQUIRE(timed_out);
+	/* And the deadline is absolute, not restarted: the outer run's 200ms budget
+	   keeps counting down across the nested run rather than beginning again
+	   after it, which is how it behaved when every vCPU owned a timer. The
+	   bound is loose enough not to be a timing test -- it only has to exclude
+	   the inner run's own 10s timeout having been left in place. */
+	REQUIRE(elapsed < 5.0);
+}
+
+TEST_CASE("A nested run does not consume the outer run's timeout", "[timer]")
+{
+	tinykvm::Machine::init();
+
+	/* Same shape, but the outer guest returns straight after the syscall. A
+	   restored deadline must not fire on a guest that is behaving: the outer
+	   run has to complete normally, and the timer must be left disarmed for
+	   whatever runs on this thread next. */
+	const auto inner_binary = build_and_load(R"M(
+int main() { return 0; }
+extern long quick(void) { return 42; }
+)M");
+	tinykvm::Machine inner { inner_binary, { .max_mem = MAX_MEMORY } };
+	inner.setup_linux({"inner2"}, env);
+	inner.run(8.0f);
+	g_inner = &inner;
+	g_inner_ran = false;
+	g_inner_error.clear();
+
+	const auto outer_binary = build_and_load(R"M(
+#include <unistd.h>
+int main() {
+	syscall(500);
+	return 0;
+}
+)M");
+	tinykvm::Machine outer { outer_binary, { .max_mem = MAX_MEMORY } };
+	outer.setup_linux({"outer2"}, env);
+	tinykvm::Machine::install_syscall_handler(
+		SYSCALL_NESTED_RUN, run_inner_machine);
+
+	std::string error;
+	try {
+		outer.run(4.0f);
+	} catch (const std::exception& e) {
+		error = e.what();
+	}
+	REQUIRE(g_inner_ran);
+	REQUIRE(g_inner_error.empty());
+	REQUIRE(error.empty());
+	REQUIRE(!outer.cpu().timed_out());
+
+	/* A second, plain run on this thread must still be timed correctly -- the
+	   nested pair above left no arming behind. */
+	tinykvm::Machine spinner { build_and_load(R"M(
+int main() { while (1) { __asm__ volatile(""); } return 0; }
+)M"), { .max_mem = MAX_MEMORY } };
+	spinner.setup_linux({"spinner"}, env);
+	bool timed_out = false;
+	try {
+		spinner.run(0.2f);
+	} catch (const tinykvm::MachineTimeoutException&) {
+		timed_out = true;
+	}
+	REQUIRE(timed_out);
+}

--- a/tests/unit/vcpu_timer.cpp
+++ b/tests/unit/vcpu_timer.cpp
@@ -1,0 +1,262 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdio>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+#include <tinykvm/machine.hpp>
+
+/* The vCPU execution timer belongs to the thread that runs the vCPU, not to
+   the vCPU and not to a VM group seat. Three things follow, and this file pins
+   all three:
+
+   1. Building a pool of forks creates no timers at all -- the count tracks the
+      number of *threads that have run a guest*, not the number of forks (and
+      not the number of seats). That is the point of the change.
+   2. A fork that migrates to another thread still times out there. This is the
+      case the old per-vCPU/per-seat timer needed explicit rebind logic for: a
+      timer bound (SIGEV_THREAD_ID) to a thread that is no longer running the
+      vCPU neither interrupts the KVM_RUN that has to be interrupted, nor stays
+      quiet on the thread it is still bound to.
+   3. ...and the thread it migrated away from is not left holding a timer that
+      fires into whatever runs there next.
+
+   /proc/self/timers is the only place a POSIX timer is visible; it needs
+   CONFIG_CHECKPOINT_RESTORE, and the counting cases self-skip without it. */
+
+extern std::vector<uint8_t> build_and_load(const std::string& code);
+
+static const uint64_t MAX_MEMORY = 32ul << 20; /* 32MB */
+static const uint64_t MAX_COWMEM =  4ul << 20; /* 4MB */
+static constexpr int POOL_SIZE = 64;
+static const std::vector<std::string> env {
+	"LC_TYPE=C", "LC_ALL=C", "USER=root"
+};
+
+/* Whether a *pooled* fork can be made to execute here. On ARM64 it cannot, on
+   this project's test host: the nested KVM_RUN that arm64_flush_guest_tlb()
+   issues for a pooled member's deferred TTBR0 flush never returns. That is
+   pre-existing and reproduces on the unmodified branch -- it is not something
+   the timer has any part in -- so the cases that need a pooled fork to *run*
+   are left to the AMD64 lane. Pooled construction and seat reuse, which is
+   where a seat used to acquire and rebind a timer, are checked on both. */
+#if defined(TINYKVM_ARCH_ARM64)
+static constexpr bool POOLED_CAN_RUN = false;
+#else
+static constexpr bool POOLED_CAN_RUN = true;
+#endif
+
+static void require_kvm()
+{
+	static bool attempted = false;
+	static bool available = false;
+	static std::string error;
+	if (!attempted) {
+		attempted = true;
+		try {
+			tinykvm::Machine::init();
+			available = true;
+		} catch (const tinykvm::MachineException& e) {
+			error = std::string(e.what()) + " (" + std::to_string(e.data()) + ")";
+		}
+	}
+	if (!available) {
+		SKIP("KVM unavailable: " << error);
+	}
+}
+
+static size_t count_posix_timers()
+{
+	FILE* f = fopen("/proc/self/timers", "r");
+	if (f == nullptr)
+		return SIZE_MAX; /* CONFIG_CHECKPOINT_RESTORE=n */
+	size_t count = 0;
+	char line[256];
+	while (fgets(line, sizeof(line), f) != nullptr) {
+		if (strncmp(line, "ID:", 3) == 0)
+			count += 1;
+	}
+	fclose(f);
+	return count;
+}
+
+/* A master exporting a function that returns immediately and one that spins
+   forever, so a fork can be made to both finish and time out on demand. */
+static tinykvm::Machine& forkable_master()
+{
+	static const std::vector<uint8_t> binary = build_and_load(R"M(
+int main() { return 0; }
+extern long quick(void) { return 42; }
+extern void spin(void) { while (1) { __asm__ volatile(""); } }
+)M");
+	static tinykvm::Machine machine { binary, { .max_mem = MAX_MEMORY } };
+	static bool prepared = false;
+	if (!prepared) {
+		prepared = true;
+		machine.setup_linux({"timer"}, env);
+		machine.run(8.0f);
+		machine.prepare_copy_on_write();
+	}
+	return machine;
+}
+
+static tinykvm::MachineOptions fork_options(bool pooled)
+{
+	tinykvm::MachineOptions options;
+	options.max_mem = MAX_MEMORY;
+	options.max_cow_mem = MAX_COWMEM;
+	options.vm_group = pooled;
+	return options;
+}
+
+TEST_CASE("A pool of forks holds no execution timers", "[timer]")
+{
+	require_kvm();
+	auto& master = forkable_master();
+	if (count_posix_timers() == SIZE_MAX) {
+		SKIP("/proc/self/timers unavailable (CONFIG_CHECKPOINT_RESTORE=n)");
+	}
+	/* The master ran above, so this thread already has its one timer -- and
+	   while nothing else runs, it is the only one the process holds. */
+	REQUIRE(count_posix_timers() == 1);
+
+	for (const bool pooled : {false, true}) {
+		std::vector<std::unique_ptr<tinykvm::Machine>> forks;
+		for (int i = 0; i < POOL_SIZE; i++) {
+			forks.push_back(std::make_unique<tinykvm::Machine>(
+				master, fork_options(pooled)));
+		}
+		/* POOL_SIZE live forks, none run: neither a fork nor a seat owns a
+		   timer. Before the change this was POOL_SIZE + 1. */
+		REQUIRE(count_posix_timers() == 1);
+
+		if (pooled && !POOLED_CAN_RUN) {
+			continue;
+		}
+		const auto quick = forks.front()->address_of("quick");
+		REQUIRE(quick != 0x0);
+		for (auto& fork : forks) {
+			fork->timed_vmcall(quick, 8.0f);
+		}
+		/* Running them changes nothing either: they all ran on this thread. */
+		REQUIRE(count_posix_timers() == 1);
+	}
+	/* And the forks going away takes nothing with it that was not there. */
+	REQUIRE(count_posix_timers() == 1);
+}
+
+TEST_CASE("A seat handed between threads costs no timer", "[timer][vm_group]")
+{
+	require_kvm();
+	auto& master = forkable_master();
+	if (count_posix_timers() == SIZE_MAX) {
+		SKIP("/proc/self/timers unavailable (CONFIG_CHECKPOINT_RESTORE=n)");
+	}
+	const size_t before = count_posix_timers();
+
+	/* Take a seat, hand it back, take it again from a different thread, twice
+	   over. Each hand-off used to be a timer_delete() plus a timer_create()
+	   because the seat's timer was bound to the previous tenant's thread. */
+	for (int i = 0; i < 8; i++) {
+		std::thread thread([&] {
+			tinykvm::Machine fork {master, fork_options(true)};
+			fork.migrate_to_this_thread();
+			REQUIRE(fork.is_forked());
+		});
+		thread.join();
+	}
+	REQUIRE(count_posix_timers() == before);
+}
+
+TEST_CASE("A fork that migrates threads still times out on its new thread", "[timer]")
+{
+	require_kvm();
+	auto& master = forkable_master();
+
+	for (const bool pooled : {false, true}) {
+		if (pooled && !POOLED_CAN_RUN) {
+			continue;
+		}
+		tinykvm::Machine fork {master, fork_options(pooled)};
+		const auto quick = fork.address_of("quick");
+		const auto spin  = fork.address_of("spin");
+		REQUIRE(quick != 0x0);
+		REQUIRE(spin  != 0x0);
+
+		/* Thread A: run once, so the fork is unambiguously bound to a thread
+		   that is not the one it is about to time out on. */
+		std::string error;
+		std::thread thread_a([&] {
+			try {
+				fork.migrate_to_this_thread();
+				fork.timed_vmcall(quick, 8.0f);
+			} catch (const std::exception& e) {
+				error = e.what();
+			}
+		});
+		thread_a.join();
+		REQUIRE(error.empty());
+
+		/* Thread B: the guest spins forever, and the 100ms timeout has to
+		   interrupt *this* thread's KVM_RUN. A timer left bound to thread A
+		   would leave this hanging until the suite is killed. */
+		bool timed_out = false;
+		std::thread thread_b([&] {
+			fork.migrate_to_this_thread();
+			try {
+				fork.timed_vmcall(spin, 0.1f);
+			} catch (const tinykvm::MachineTimeoutException&) {
+				timed_out = true;
+			} catch (const std::exception& e) {
+				error = e.what();
+			}
+		});
+		thread_b.join();
+		REQUIRE(error.empty());
+		REQUIRE(timed_out);
+	}
+}
+
+TEST_CASE("A timeout leaves no timer firing on the thread it migrated from", "[timer]")
+{
+	require_kvm();
+	auto& master = forkable_master();
+	tinykvm::Machine fork {master, fork_options(false)};
+	const auto quick = fork.address_of("quick");
+	const auto spin  = fork.address_of("spin");
+	REQUIRE(quick != 0x0);
+	REQUIRE(spin  != 0x0);
+
+	/* Time out on thread A. The timer's 20ms re-arm interval is what made a
+	   stale binding dangerous: it keeps firing at whichever thread the timer
+	   is bound to, timing out whatever innocent guest runs there next. */
+	bool timed_out = false;
+	std::string error;
+	std::thread thread_a([&] {
+		fork.migrate_to_this_thread();
+		try {
+			fork.timed_vmcall(spin, 0.1f);
+		} catch (const tinykvm::MachineTimeoutException&) {
+			timed_out = true;
+		} catch (const std::exception& e) {
+			error = e.what();
+		}
+	});
+	thread_a.join();
+	REQUIRE(error.empty());
+	REQUIRE(timed_out);
+
+	/* A short, well-behaved call back on this thread must complete. The
+	   generous timeout means only a *spurious* signal can fail it. */
+	fork.migrate_to_this_thread();
+	fork.timed_vmcall(quick, 8.0f);
+
+	/* One timer per thread that ran a guest: this one, plus thread A's -- and
+	   thread A's went away when thread A did. */
+	const size_t timers = count_posix_timers();
+	if (timers != SIZE_MAX) {
+		REQUIRE(timers == 1);
+	}
+}


### PR DESCRIPTION
Both halves of varnish/fast-agent#13. Rebased onto `fast-agent` after #115 and #116 landed, so this is no longer stacked — base is `fast-agent` directly.

## 1. One execution timer per thread, not per vCPU or per seat

Every vCPU created its own POSIX timer at construction. A pool of N warm forks held N kernel `k_itimer`s that nothing was using; and because the timer is thread-bound (`SIGEV_THREAD_ID`/`sigev_tid`), a VM group seat handed to a different thread had to `timer_delete()` and re-create its own before it could run — logic duplicated in both arches' `init_from_seat()` and again in `migrate_to_this_thread()`.

`Machine::this_thread_vcpu_timer()` creates one timer per thread on first use and deletes it at thread exit; `vCPU::run()`/`disable_timer()` arm and disarm that one. **N timers → one per worker thread**, and the rebind question disappears: a timer created by the thread that uses it is always bound correctly.

Nothing is lost by the sharing, because the timeout signal was **already** per-thread rather than per-vCPU — the `SIGUSR2` handler sets a `thread_local timer_was_triggered` and `vCPU::run()` clears it on entry. Only one vCPU can meaningfully be inside `run()` on a thread at a time, and a nested `run()` on the same thread already clobbered that flag before this change.

Gone with it: `vCPU::timer_id`/`timer_tid`, `VmGroupSeat::timer_id`/`owner_tid`, both rebind blocks, the seat teardown's `timer_delete`, and the body of `migrate_to_this_thread()` — kept as a documented no-op, since callers outside this tree (fast-agent's bridge, 9 sites) wrap every thread hand-off in it.

**One trap worth stating, because the old code had the same shape:** `nullptr` is not a usable "no timer" sentinel. glibc encodes a signal-notified `timer_t` as the bare kernel timer id, so the *first* timer a process creates is literally `(timer_t)0`. Treated as "none" it is re-created on the next call and then leaked — observed here as two timers on one thread, and as a run whose armed 20 ms-interval timer nothing ever disarmed. `this_thread_vcpu_timer()` tracks creation with its own flag.

## 2. Deferred vCPU bring-up on x86 (`MachineOptions::lazy_vcpu_bringup`)

`KVM_SET_CPUID2` (the expensive one), `KVM_SET_XCRS` and `KVM_SET_MSRS` move from fork construction to the first run — `vCPU::complete_bringup()`, reached from `run_once()` next to `ensure_kvm_run()`, the same lazy pattern as the `kvm_run` mapping. A fork created and destroyed without ever running (warm-pool churn) skips them entirely, and under pooling a seat taken and handed straight back keeps its CPUID *owed* for the next tenant instead of spending it: `seat.vcpu_initialized` is claimed from the run path now, not from construction.

Two flags rather than one, so the deferred path issues exactly what the eager path did — CPUID2 at most once per vCPU fd (KVM rejects a changed CPUID once the vCPU has run, and a seat's fd outlives its tenants), XCRS/MSRS once per tenant. Order preserved: XCR0 is validated against the guest CPUID, so CPUID2 goes first.

**Opt-in, default `TINYKVM_LAZY_VCPU_BRINGUP_DEFAULT=false`**, matching how `lazy_vcpu_mmap` landed. This is a deliberate, conservative call: I could not *run* the x86 path here (aarch64 host), only compile-check it, and defaulting an unexecuted code path on in a shared library is not a call to make blind. **Flipping it on wants one x86 validation run.** There is no ARM64 half — `KVM_ARM_VCPU_INIT` is already once per group seat rather than once per fork, and there is no XCRS/MSRS equivalent.

## Profile — PROVISIONAL, NOT AUTHORITATIVE

**This box was not exclusive during the run** (load average 1.7 → 2.6 across it; the maintainer is using it). `docs/operations/loadtest-kernel-tuning.md` § Exclusive box and fast-agent#26 make exclusivity a hard A/B rule, so **these numbers are indicative only and must be re-run in an exclusive window before they go anywhere near the whitepaper.** They also cover the ARM64 half only, for the same reason the flag defaults off: no x86 host.

Rig: unpooled forks of a trivial static guest, `aarch64` (Fedora Asahi, 16 KiB host pages, 12 cores), Release, N=2000 × 4 reps, base = `3013df3`. Both sides of the trade measured, as the triage asked.

| | base (3013df3) | this branch |
|---|---|---|
| **live POSIX timers** @ 2000 forks | **2001** | **1** |
| cold populate, ms/fork (median, range) | 0.177 (0.166–0.202) | 0.167 (0.161–0.188) |
| **first turn** p50 / p99 | 102.9 µs / 118.5 µs | 100.4 µs / 116.6 µs |
| warm turn p50 / p99 | 16.2 µs / 19.7 µs | 16.0 µs / 19.4 µs |
| teardown, ms/fork | 2.196 | 2.194 |

Also run at N=8000 (3 reps): populate 0.448 → 0.454 ms/fork, first-turn p50 501 → 502 µs, timers 8001 → 1. Same conclusion.

**Read honestly:** on ARM64 at these N the wall-clock effect is **not measurable** — every timing difference is inside the run-to-run spread of a non-exclusive box. That is consistent with the issue's own archived estimate (~0.33 ns/fork/fork), which only becomes visible at populate scales well past 8k. What this change definitely buys is **structural**: 2001 → 1 kernel timer objects, no per-hand-off `timer_delete`+`timer_create` on seat migration, and — the part the profile cannot show from here — the x86 `KVM_SET_CPUID2` that a never-run fork no longer issues at all. **The first-turn side of the trade shows no regression**, which is the risk the triage flagged.

## Verification

- **ARM64 (this host, real `/dev/kvm`):** full unit suite green — including #116's new cross-process `arm64_fork` case — except the pre-existing `arm64_elf` *"ARM64 runs a dynamic Python guest"* failure (`writable_page_at: l2 entry not writable`), which reproduces on the unmodified branch.
- **AMD64:** compile-checked only. Whole library plus **every** AMD64 unit-test TU (incl. #116's additions to `fork.cpp` and `lazy_kvm_run.cpp`), `-Wall -Wextra`, clean, in **both** A/B configurations — defaults, and `LAZY_VCPU_BRINGUP=true` + `LAZY_VCPU_MMAP=true` + `VM_GROUP=true`. The AMD64 KVM tests must be *run* before merge; they are the only thing that exercises half 2 at all.

## Two pre-existing ARM64 findings, reported not fixed

Both reproduce on the unmodified branch and are out of scope here, but they shaped what this PR can test:

1. **Running a pooled (`vm_group`) fork hangs on this host.** It blocks in the nested `KVM_RUN` that `arm64_flush_guest_tlb()` issues for a pooled member's deferred TTBR0 flush — which is armed with `ticks = 0`, so no timer can ever interrupt it. Stack: `Machine::run` → `vCPU::run` → `flush_pending_guest_tlb` → `arm64_flush_guest_tlb` → `vCPU::run(0)` → `run_once` → `ioctl` (never returns). There is no ARM64 `vm_group` unit test registered, so nothing in the suite catches it. The cases in `vcpu_timer.cpp` that need a pooled fork to *execute* are therefore AMD64-only, marked as such in the file.
2. `arm64_elf`'s dynamic-Python case, as above.

Both are plausibly the same root cause: this host has **16 KiB pages**, and the ARM64 paths look like they assume 4 KiB host pages. Worth a dedicated issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
