### PR TITLE
fix(arm64): promote read-only mmap-backed L2 blocks on the master instead of throwing

### DIFF
--- a/lib/tinykvm/arm64/paging.cpp
+++ b/lib/tinykvm/arm64/paging.cpp
@@ -467,6 +467,21 @@ WritablePage writable_page_at(vMemory& memory, uint64_t addr, uint64_t verify_fl
 		// host or guest now needs to write to.
 		if (((e2 & DESC_CLONEABLE) || !is_writable(e2)) && memory.split_hugepages)
 			split_l2_block(memory, e2);
+		else if (!is_writable(e2) && (e2 & DESC_CLONEABLE) == 0
+				&& !memory.machine.is_forked()) {
+			// A present, read-only, non-cloneable block on the identity-mapped
+			// master (same case as the L3 promote below): splitting is not an
+			// option here -- a master has no bank pages for the L3 table.
+			// Promote the whole block in place; makecow re-marks it
+			// copy-on-write at snapshot.
+			e2 &= ~DESC_AP_RO;
+			auto* data = memory.page_at(e2 & DESC_ADDR_MASK);
+			return WritablePage{
+				.page = (char*)data + (addr & (L2_BLOCK_SIZE - 1)),
+				.entry = e2,
+				.size = L2_BLOCK_SIZE,
+			};
+		}
 		else if (!has_flags(e2, verify_flags) || !is_writable(e2))
 			memory_exception("writable_page_at: l2 entry not writable", addr, e2);
 		else {

--- a/tests/unit/arm64_elf.cpp
+++ b/tests/unit/arm64_elf.cpp
@@ -1,7 +1,6 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <string>
-#include <unistd.h>
 #include <vector>
 #include <unistd.h> /* access(), R_OK -- not pulled in transitively by GCC 16 */
 #include <tinykvm/machine.hpp>

--- a/tests/unit/nested_timer.cpp
+++ b/tests/unit/nested_timer.cpp
@@ -63,6 +63,7 @@ extern long quick(void) { return 42; }
 
 	/* Outer: runs the inner machine from a syscall, then spins forever. */
 	const auto outer_binary = build_and_load(R"M(
+#define _GNU_SOURCE /* syscall() -- implicit decl is an error on GCC 16 */
 #include <unistd.h>
 int main() {
 	syscall(500);
@@ -121,6 +122,7 @@ extern long quick(void) { return 42; }
 	g_inner_error.clear();
 
 	const auto outer_binary = build_and_load(R"M(
+#define _GNU_SOURCE /* syscall() -- implicit decl is an error on GCC 16 */
 #include <unistd.h>
 int main() {
 	syscall(500);


### PR DESCRIPTION
Root-causes and fixes the pre-existing ARM64 unit-test failure unmasked by #116 (tracked as varnish/fast-agent#92): `ARM64 runs a dynamic Python guest` fails with `writable_page_at: l2 entry not writable`.

## Root cause

With `mmap_backed_files`, `mmap_backed_area` serves a large `.so` (libpython, >4MB) as host-mmap'd 2MB L2 blocks and `set_protections(PROT_READ|PROT_EXEC)` marks them **read-only** in the guest page tables. ld.so then maps the `.data` segment read-write *over* part of that region; being small, that mmap takes the preadv fallback in the mmap syscall handler, whose `writable_page_at()` reaches the L2-leaf branch with no way out:

* splitting the block is gated on `split_hugepages`, which defaults to `false` (and enabling it only trades the error for `Out of working memory`: `split_l2_block()` allocates the L3 table from the memory banks, and a non-forked master has zero bank pages — `max_cow_mem` defaults to 0);
* otherwise the branch throws.

AMD64 structurally never sees this: its `WritablePage::set_protections()` is a no-op (bare `return;` at the top), so file-backed hugepages simply stay writable on the master. The ARM64 port implemented `set_protections` for real and inherited a case x86 never exercises.

## Fix

Give the L2-leaf branch the same escape hatch the L3 path directly below it already has for this exact situation: on the identity-mapped **master**, promote the read-only, non-cloneable block writable in place (`e2 &= ~DESC_AP_RO`) and return it. No bank allocation is needed, and `foreach_page_makecow()` re-marks the block copy-on-write at snapshot time. Fork behavior is unchanged — forks have bank pages, so the existing split path continues to handle them.

## Ride-alongs (GCC 16)

* `nested_timer.cpp`: the embedded guest programs call `syscall()` without `_GNU_SOURCE`; under `-std=c11` the declaration is hidden and GCC 16 makes implicit declarations a hard error, so the guests never compiled and both test cases failed.
* `arm64_elf.cpp`: drop a duplicated `#include <unistd.h>`.

## Testing

On the aarch64/16K Asahi box (Fedora 44, GCC 16): the Python guest test passes (output, exit code, and the mmap-ranges assertion all hold), and the full ARM64 unit suite is green — 9/9, including fork/CoW and vm_group tests.

Fixes varnish/fast-agent#92.

🤖 Generated with [Claude Code](https://claude.com/claude-code)